### PR TITLE
Use Scribe's undo manager

### DIFF
--- a/src/noting-vdom.js
+++ b/src/noting-vdom.js
@@ -42,23 +42,25 @@ exports.mutate = function(domElement, callback) {
 exports.mutateScribe = function(scribe, callback) {
   var selection = new scribe.api.Selection();
 
-  // Place markers and create virtual trees.
-  // We'll use the markers to determine where a selection starts and ends.
-  selection.placeMarkers();
+  scribe.transactionManager.run(function () {
+    // Place markers and create virtual trees.
+    // We'll use the markers to determine where a selection starts and ends.
+    selection.placeMarkers();
 
-  exports.mutate(scribe.el, function(treeFocus) {
+    exports.mutate(scribe.el, function(treeFocus) {
 
-    callback(treeFocus, selection);
+      callback(treeFocus, selection);
 
+    });
+
+    // Place caret (necessary to do this explicitly for FF).
+    // Currently works by selecting before and after real DOM elements, so
+    // cannot use VDOM for this, yet.
+    selection.selectMarkers();
+
+    // We need to make sure we clean up after ourselves by removing markers
+    // when we're done, as our functions assume there's either one or two
+    // markers present.
+    selection.removeMarkers();
   });
-
-  // Place caret (necessary to do this explicitly for FF).
-  // Currently works by selecting before and after real DOM elements, so
-  // cannot use VDOM for this, yet.
-  selection.selectMarkers();
-
-  // We need to make sure we clean up after ourselves by removing markers
-  // when we're done, as our functions assume there's either one or two
-  // markers present.
-  selection.removeMarkers();
 };


### PR DESCRIPTION
Use Scribe's undo manager. There are a couple of caveats, but those are due to how undo works in Scribe.
1. If you note a few things, and then undo, all of the notes you created will be undone. Not just the last one.
2. Undo only works within the current Scribe instance. (Would be nice to have some helpers in Scribe for operating on all instances on the page).

On a different note (pun intended), you might want to have a look at: https://github.com/guardian/scribe-plugin-noting/commit/c77441886825e0394a2e9ac00c4803ad8bda2466, as I accidentally committed that to master.
