### PR TITLE
Correct the main value in bower.json so that plumber picks up the plugin

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "hugo.gibson@theguardian.com"
   ],
   "description": "Adds notes to scribe",
-  "main": "src/scribe-plugin-noting",
+  "main": "./scribe-plugin-noting.js",
   "version": "0.2.8",
   "license": "Apache 2"
 }


### PR DESCRIPTION
This is needed as otherwise Plumber doesn't include the file in any minification
or hashing. The `bower.json` is not derived from the file in the `master` branch 
so the change needs to be made directly in dist.
