### PR TITLE
added postinstall to build assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "selenium-webdriver": "~2.41.0"
   },
   "scripts": {
-    "test": "./run-tests.sh"
+    "test": "./run-tests.sh",
+    "postinstall": "plumber build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Even tho we don't compile to UMD we should probably build out the assets so they can be required.  If you don't want to do this then we should probably include the built assets in the src?
