### PR TITLE
Increase performance across hundreds of notes (patch)

### DIFF
--- a/src/api/note-toggle.js
+++ b/src/api/note-toggle.js
@@ -97,7 +97,10 @@ function generateUUID(){
 // by information.
 function updateNoteProperties(noteSegments) {
   updateStartAndEndClasses(noteSegments);
-  noteSegments.forEach(updateEditedBy);
+
+  // FIXME JP 20/11/14
+  // This is removed as it causes significant performance issues
+  //noteSegments.forEach(updateEditedBy);
 
   var uuid = generateUUID();
   noteSegments.forEach(function (segment) {


### PR DESCRIPTION
I've removed the updating of note meta data as this causes significant performance issues when a document contains hundreds of notes.  Whilst not a fix this patch should sort performance until we can refactor this feature.
