### PR TITLE
Remove expensive update all notes call

### DIFF
--- a/src/api/note-toggle.js
+++ b/src/api/note-toggle.js
@@ -448,7 +448,7 @@ function mergeIfNecessary(treeFocus) {
   // the last note segment of a note).
   function criteria(note) { return inconsistentTimestamps(note) || lacksStartOrEnd(note); }
 
-  vdom.findAllNotes(treeFocus).filter(criteria).forEach(updateNoteProperties);
+  //vdom.findAllNotes(treeFocus).filter(criteria).forEach(updateNoteProperties);
 }
 
 


### PR DESCRIPTION
This should go some way to alleviating the unresponsive script error some users are getting on heavily noted content.  Would appreciate some eyes from @robinedman on this one, may be the case there's other quick wins in this area. 
