### PR TITLE
Revert "Travis: build config update"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,28 @@ language: node_js
 node_js:
   - 0.10
 
-sudo: false
-
-cache:
-  directories:
-    - node_modules
-    - bower_components
-
 addons:
   sauce_connect:
     username: scribe-ci
     access_key: 4be9eeed-61de-4948-b18d-f7f655e9e4b0
 env:
   matrix:
-    - BROWSER_NAME='firefox' BROWSER_VERSION='31' PLATFORM='Windows XP'
-    - BROWSER_NAME='firefox' BROWSER_VERSION='32' PLATFORM='Windows XP'
-    - BROWSER_NAME='firefox' BROWSER_VERSION='33' PLATFORM='Windows XP'
-    - BROWSER_NAME='firefox' BROWSER_VERSION='33' PLATFORM='OS X 10.9'
-    - BROWSER_NAME='chrome' BROWSER_VERSION='35' PLATFORM='Windows XP'
-    - BROWSER_NAME='chrome' BROWSER_VERSION='36' PLATFORM='Windows XP'
-    - BROWSER_NAME='chrome' BROWSER_VERSION='37' PLATFORM='Windows XP'
-    - BROWSER_NAME='chrome' BROWSER_VERSION='38' PLATFORM='Windows XP'
-    - BROWSER_NAME='chrome' BROWSER_VERSION='38' PLATFORM='OS X 10.8'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='21' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='22' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='23' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='24' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='25' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='26' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='27' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='28' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='27' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='28' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='29' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='30' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='31' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='32' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='33' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='34' PLATFORM='Windows XP'
 
 before_script:
   - npm install -g bower


### PR DESCRIPTION
Reverts guardian/scribe-plugin-noting#33

All tests started failing because bower can't be found. Guessing the `before_script` command isn't executed.
