### PR TITLE
Make the height relative

### DIFF
--- a/src/skins/gu-noting.less
+++ b/src/skins/gu-noting.less
@@ -92,7 +92,7 @@
         padding: 0;
         margin: 0 2px;
         width: 14px;
-        height: 20px;
+        height: 1em;
         display: inline-block;
         overflow: hidden;
         text-indent: 24px;


### PR DESCRIPTION
Make the height of the collapsed span relative so it's the same height as the surrounding text