### PR TITLE
Fix note toggle bugs

### DIFF
--- a/src/actions/noting/toggle-note-classes.js
+++ b/src/actions/noting/toggle-note-classes.js
@@ -1,5 +1,8 @@
 var _ = require('lodash');
 var toggleClass = require('../vdom/toggle-class');
+var addClass = require('../vdom/add-class');
+var removeClass = require('../vdom/remove-class');
+var collapseState = require('../../utils/collapse-state');
 
 module.exports = function toggleNoteClasses(notes, className) {
 
@@ -10,8 +13,21 @@ module.exports = function toggleNoteClasses(notes, className) {
   notes = _.isArray(notes) ? notes : [notes];
   notes = _.flatten(notes);
 
+  var action;
+  if (notes.length === 1) {
+    //if we have only one note we can assume that it should be toggled
+    //because we assume it has been clicked
+    action = toggleClass;
+  } else {
+    //if we have more than one note then we want them all to share state
+    var state = collapseState.get();
+    state ? action = removeClass : action = addClass;
+    collapseState.set(!state);
+  }
+
   notes.forEach(function(vNode) {
-    toggleClass(vNode, className);
+    vNode = (vNode.vNode || vNode);
+    action(vNode, className);
   });
 
 };

--- a/src/noting-commands.js
+++ b/src/noting-commands.js
@@ -10,7 +10,7 @@ var noteToggle = require('./api/note-toggle');
 var noteCollapse = require('./api/note-collapse');
 var vdom = require('./noting-vdom');
 var _ = require('lodash');
-
+var scribeSelector;
 
 /**
  * Initialise noting commands
@@ -23,7 +23,7 @@ exports.init = function(scribe, config) {
 
   // initialise scribe element selector
   // TODO: Extract the configuration varialbles into its own module.
-  noteCollapse.scribeInstancesSelector = config.scribeInstancesSelector;
+  scribeSelector = (config.scribeInstancesSelector || '.scribe');
 
   scribe.commands.note = createNoteToggleCommand(scribe);
   scribe.commands.noteCollapseToggle = createCollapseToggleCommand(scribe);
@@ -95,7 +95,7 @@ function createCollapseToggleAllCommand(scribe) {
     // to be available to all Scribe instances. Otherwise the state in different
     // instances can get out of sync.
     var state = !window._scribe_plugin_noting__noteCollapsedState,
-        scribeInstances = _.toArray(document.querySelectorAll(noteCollapse.scribeInstancesSelector));
+        scribeInstances = _.toArray(document.querySelectorAll(scribeSelector));
 
     scribeInstances.forEach(function (instance) {
 

--- a/src/utils/collapse-state.js
+++ b/src/utils/collapse-state.js
@@ -1,0 +1,10 @@
+var state = false;
+
+module.exports = {
+  get: function() {
+    return state;
+  },
+  set: function(val) {
+    state = val;
+  }
+};

--- a/test/integration/create-note.spec.js
+++ b/test/integration/create-note.spec.js
@@ -16,6 +16,7 @@ beforeEach(function() {
 });
 
 var note = require('./helpers/create-note');
+
 var selectionIsInsideNote = require('./helpers/selection-within-note');
 
 describe('Creating Scribe Notes', function() {

--- a/test/integration/toggle-notes.spec.js
+++ b/test/integration/toggle-notes.spec.js
@@ -1,0 +1,38 @@
+var chai = require('chai');
+var webdriver = require('selenium-webdriver');
+var helpers = require('scribe-test-harness/helpers');
+
+var expect = chai.expect;
+
+var when = helpers.when;
+var given = helpers.given;
+var givenContentOf = helpers.givenContentOf;
+
+var scribeNode;
+var driver;
+beforeEach(function() {
+  scribeNode = helpers.scribeNode;
+  driver = helpers.driver;
+});
+
+describe('Toggle Scribe Notes', function(){
+
+  //checks note toggle function on all notes see:
+  //https://github.com/guardian/scribe-plugin-noting/issues/51
+  given('we have two notes in different collapsed states', function(){
+    givenContentOf('<p>On the 24th of February, <gu-note class="note note--collapsed">1815, the</gu-note> look-out at <gu-note class="note">Notre-Dame de</gu-note> la Garde signalled the three-master, the Pharaon from Smyrna</p>', function() {
+      it.only('should toggle both notes into the correct state', function (){
+
+        driver.executeScript(function(){
+          window.scribe.commands.noteCollapseToggleAll.execute();
+        })
+        .then(function(){
+          return scribeNode.getInnerHTML()
+        })
+        .then(function(innerHTML){
+          expect(innerHTML.match(/note--collapsed/g).length).to.equal(2);
+        });
+      });
+    });
+  });
+});

--- a/test/unit/actions/noting/toggle-note-classes.spec.js
+++ b/test/unit/actions/noting/toggle-note-classes.spec.js
@@ -2,6 +2,8 @@ var path = require('path');
 var chai = require('chai');
 var expect = chai.expect;
 
+var collapseState = require(path.resolve(process.cwd(), 'src/utils/collapse-state'));
+
 var h = require('virtual-hyperscript');
 
 var toggleNoteClasses = require(path.resolve(process.cwd(), 'src/actions/noting/toggle-note-classes'));
@@ -9,6 +11,9 @@ var toggleNoteClasses = require(path.resolve(process.cwd(), 'src/actions/noting/
 describe('toggleClass()', function() {
 
   it('should toggle a class on all notes', function() {
+
+    //explicitly set the state
+    collapseState.set(false);
 
     var notes = [
       h('gu-note'),


### PR DESCRIPTION
This PR fixes: https://github.com/guardian/scribe-plugin-noting/issues/51

![noting-fix](https://cloud.githubusercontent.com/assets/1975139/5633306/d8fd3a0a-95cd-11e4-958c-5aeafb607e57.gif)

### QA
- create two notes
- toggle one note
- click toggle all notes
- ensure both notes are collapsed