### PR TITLE
Added require fix for immutable.js

### DIFF
--- a/test/app/index.html
+++ b/test/app/index.html
@@ -24,7 +24,8 @@
           // but will not pass along the 'scribe' AMD module.
           'scribe-common': 'bower_components/scribe-common',
           'lodash-amd': 'bower_components/lodash-amd',
-          'lodash': 'bower_components/lodash/dist/lodash'
+          'lodash': 'bower_components/lodash/dist/lodash',
+          'immutable': 'bower_components/immutable'
         }
       });
 


### PR DESCRIPTION
On a fresh checkout, when trying to run the test suite you get:

Uncaught Error: Script error for: immutable/dist/immutable
http://requirejs.org/docs/errors.html#scripterror

This is because scribe references immutable like this:
`'immutable/dist/immutable'`

Adding a reference to the `require.config.paths` fixes this until we can get a fix in the scribe codebase.
