### PR TITLE
Refactor note toggle (complete)

### DIFF
--- a/src/actions/noting/create-note-from-selection.js
+++ b/src/actions/noting/create-note-from-selection.js
@@ -72,7 +72,7 @@ module.exports = function createNoteFromSelection(focus){
       // The user's selection ends within a paragraph.
       // To place a marker we have to place an element inbetween the note barrier
       // and the marker, or Chrome will place the caret inside the note.
-      focusOutsideNote.insertBefore([new VText('\u200B'), createVirtualScribeMarker()]);
+      outsideNoteFocus.insertBefore([new VText('\u200B'), createVirtualScribeMarker()]);
     } else {
 
       // The user's selection ends with a whole paragraph being selected. Now

--- a/src/actions/noting/create-note-from-selection.js
+++ b/src/actions/noting/create-note-from-selection.js
@@ -22,7 +22,7 @@ var removeEmptyNotes = require('../../actions/noting/remove-empty-notes');
 // Note that we will mutate the tree.
 module.exports = function createNoteFromSelection(focus){
 
-  if(!isVFocus(focus)){
+  if (!isVFocus(focus)){
     errorHandle('Only a valid VFocus element can be passed to createNoteFromSelection, you passed: %s', focus);
   }
   // We want to wrap text nodes between the markers. We filter out nodes that have

--- a/src/actions/noting/create-note-from-selection.js
+++ b/src/actions/noting/create-note-from-selection.js
@@ -10,7 +10,7 @@ var removeErroneousBrTags = require('./remove-erroneous-br-tags');
 var removeScribeMarkers = require('./remove-scribe-markers');
 var findLastNoteSegment = require('../../utils/noting/find-last-note-segment');
 var findEntireNote = require('../../utils/noting/find-entire-note');
-var resetnoteSegmentClasses = require('./reset-note-segment-classes');
+var resetNoteSegmentClasses = require('./reset-note-segment-classes');
 var notesCache = require('../../utils/noting/note-cache');
 var isNotWithinNote = require('../../utils/noting/is-not-within-note');
 var isParagraph = require('../../utils/vfocus/is-paragraph');
@@ -51,7 +51,7 @@ module.exports = function createNoteFromSelection(focus){
   // Update note properties (merges if necessary).
   var lastNoteSegment = findLastNoteSegment(toWrapAndReplace[0]);
   var noteSegments = findEntireNote(lastNoteSegment);
-  resetnoteSegmentClasses(noteSegments);
+  resetNoteSegmentClasses(noteSegments);
 
   // We need to clear the cache, and this has to be done before we place
   // our markers or we'll end up placing the cursor inside the note instead

--- a/src/actions/noting/create-note-from-selection.js
+++ b/src/actions/noting/create-note-from-selection.js
@@ -1,0 +1,94 @@
+var _ = require('lodash');
+var VText = require('vtree/vtext');
+
+var isVFocus = require('../../utils/vfocus/is-vfocus');
+var errorHandle = require('../../utils/error-handle');
+var findTextBetweenScribeMarkers = require('../../utils/noting/find-text-between-scribe-markers');
+var getNoteDataAttributes = require('../../utils/get-note-data-attrs');
+var wrapInNote = require('./wrap-in-note');
+var removeErroniousBrTags = require('./remove-erroneous-br-tags');
+var removeScribeMarkers = require('./remove-scribe-markers');
+var findLastNoteSegment = require('../../utils/noting/find-last-note-segment');
+var findEntireNote = require('../../utils/noting/find-entire-note');
+var resetnoteSegmentClasses = require('./reset-note-segment-classes');
+var notesCache = require('../../utils/noting/note-cache');
+var isNotWithinNote = require('../../utils/noting/is-not-within-note');
+var isParagraph = require('../../utils/vfocus/is-paragraph');
+var createVirtualScribeMarker = require('../../utils/create-virtual-scribe-marker');
+var isNotEmpty = require('../../utils/vfocus/is-not-empty');
+var removeEmptyNotes = require('../../actions/noting/remove-empty-notes');
+
+// treeFocus: tree focus of tree containing two scribe markers
+// Note that we will mutate the tree.
+module.exports = function createNoteFromSelection(focus){
+
+  if(!isVFocus(focus)){
+    errorHandle('Only a valid VFocus element can be passed to createNoteFromSelection, you passed: %s', focus);
+  }
+  // We want to wrap text nodes between the markers. We filter out nodes that have
+  // already been wrapped.
+  var toWrapAndReplace = findTextBetweenScribeMarkers(focus).filter(isNotWithinNote);
+
+  //wrap text nodes
+  var noteDataSet = getNoteDataAttributes();
+  var wrappedTextNodes = toWrapAndReplace.map(focus => wrapInNote(focus.vNode, noteDataSet));
+
+  // Replace the nodes in the tree with the wrapped versions.
+  _.zip(toWrapAndReplace, wrappedTextNodes).forEach(focusAndReplacementVNode => {
+    var focus = focusAndReplacementVNode[0];
+    var replacementVNode = focusAndReplacementVNode[1];
+    focus.replace(replacementVNode);
+  });
+
+  // If we end up with an empty note a <BR> tag would be created. We have to do
+  // this before we remove the markers.
+  removeErroniousBrTags(focus);
+
+  // We want to place the caret after the note. First we have to remove the
+  // existing markers.
+  removeScribeMarkers(focus);
+
+  // Update note properties (merges if necessary).
+  var lastNoteSegment = findLastNoteSegment(toWrapAndReplace[0]);
+  var noteSegments = findEntireNote(lastNoteSegment);
+  resetnoteSegmentClasses(noteSegments);
+
+  // We need to clear the cache, and this has to be done before we place
+  // our markers or we'll end up placing the cursor inside the note instead
+  // of immediately after it.
+  //
+  // TODO: Revisit our caching strategy to make it less of a "foot gun", or
+  // refactor so that we do less tree traversals and remove the caching.
+  notesCache.set(focus);
+
+  // Now let's place that caret.
+  var outsideNoteFocus = noteSegments.splice(-1)[0].find(isNotWithinNote);
+
+  // We guard against the case when the user notes the last piece of text in a
+  // Scribe instance. In that case we don't bother placing the cursor.
+  // (What behaviour would a user expect?)
+  if (outsideNoteFocus){
+    if (isParagraph(outsideNoteFocus)){
+      // The user's selection ends within a paragraph.
+      // To place a marker we have to place an element inbetween the note barrier
+      // and the marker, or Chrome will place the caret inside the note.
+      focusOutsideNote.insertBefore([new VText('\u200B'), createVirtualScribeMarker()]);
+    } else {
+
+      // The user's selection ends with a whole paragraph being selected. Now
+      // we need to place the caret in a different manner (or we will end up
+      // with a new empty paragraph). So we place the caret at the start of the
+      // next paragraph.
+
+      var firstNodeWithChildren = outsideNoteFocus.find(isNotEmpty);
+      if (firstNodeWithChildren){
+        firstNodeWithChildren.insertBefore(createVirtualScribeMarker());
+      }
+
+    }
+  }
+
+  removeEmptyNotes(focus);
+
+  return focus;
+};

--- a/src/actions/noting/create-note-from-selection.js
+++ b/src/actions/noting/create-note-from-selection.js
@@ -6,7 +6,7 @@ var errorHandle = require('../../utils/error-handle');
 var findTextBetweenScribeMarkers = require('../../utils/noting/find-text-between-scribe-markers');
 var getNoteDataAttributes = require('../../utils/get-note-data-attrs');
 var wrapInNote = require('./wrap-in-note');
-var removeErroniousBrTags = require('./remove-erroneous-br-tags');
+var removeErroneousBrTags = require('./remove-erroneous-br-tags');
 var removeScribeMarkers = require('./remove-scribe-markers');
 var findLastNoteSegment = require('../../utils/noting/find-last-note-segment');
 var findEntireNote = require('../../utils/noting/find-entire-note');
@@ -42,7 +42,7 @@ module.exports = function createNoteFromSelection(focus){
 
   // If we end up with an empty note a <BR> tag would be created. We have to do
   // this before we remove the markers.
-  removeErroniousBrTags(focus);
+  removeErroneousBrTags(focus);
 
   // We want to place the caret after the note. First we have to remove the
   // existing markers.

--- a/src/actions/noting/ensure-note-integrity.js
+++ b/src/actions/noting/ensure-note-integrity.js
@@ -7,7 +7,7 @@ var removeErroneousBrTags = require('./remove-erroneous-br-tags');
 
 module.exports = function ensureNoteIntegrity(focus){
 
-  if(!isVFocus(focus)){
+  if (!isVFocus(focus)){
     errorhandle('Only a valid VFocus element can be passed to ensureNoteIntegrity, you passed: %s', focus);
   }
 

--- a/src/actions/noting/ensure-note-integrity.js
+++ b/src/actions/noting/ensure-note-integrity.js
@@ -1,0 +1,19 @@
+var isVFocus = require('../../utils/vfocus/is-vfocus');
+var errorHandle = require('../../utils/error-handle');
+var noteCache = require('../../utils/noting/note-cache');
+var mergeIfNecessary = require('./merge-if-necessary');
+var resetNoteBarriers = require('./reset-note-barriers');
+var removeErroneousBrTags = require('./remove-erroneous-br-tags');
+
+module.exports = function ensureNoteIntegrity(focus){
+
+  if(!isVFocus(focus)){
+    errorhandle('Only a valid VFocus element can be passed to ensureNoteIntegrity, you passed: %s', focus);
+  }
+
+  noteCache.set(focus);
+  mergeIfNecessary(focus);
+  resetNoteBarriers(focus);
+  removeErroneousBrTags(focus);
+
+}

--- a/src/actions/noting/merge-if-necessary.js
+++ b/src/actions/noting/merge-if-necessary.js
@@ -1,0 +1,63 @@
+var _ = require('lodash');
+var isVFocus = require('../../utils/vfocus/is-vfocus');
+var errorHandle = require('../../utils/error-handle');
+var findAllNotes = require('../../utils/noting/find-all-notes');
+var resetNoteSegmentClasses = require('./reset-note-segment-classes');
+
+/*
+   Example. We have two notes:
+   <p>
+   <gu-note>Some noted text</gu-note>| and some other text inbetween |<gu-note>More noted text</gu-note>
+   </p>
+
+   We press BACKSPACE, deleting the text, and end up with:
+   <p>
+   <gu-note data-note-edited-by="Edmond Dantès" data-note-edited-date="2014-09-15T16:49:20.012Z">Some noted text</gu-note><gu-note data-note-edited-by="Lord Wilmore" data-note-edited-date="2014-09-20T10:00:00.012Z">More noted text</gu-note>
+   </p>
+
+   This function will merge the notes:
+   <p>
+   <gu-note data-note-edited-by="The Count of Monte Cristo" data-note-edited-date="2014-10-10T17:00:00.012Z">Some noted text</gu-note><gu-note data-note-edited-by="The Count of Monte Cristo" data-note-edited-date="2014-10-10T17:00:00.012Z">More noted text</gu-note>
+   </p>
+
+   The last user to edit "wins", the rationale being that they have approved
+   these notes by merging them. In this case all note segments are now
+   listed as being edited by The Count of Monte Cristo and the timestamp
+   shows the time when the notes were merged.
+   */
+module.exports = function mergeIfNecessary(focus){
+
+  if(!isVFocus(focus)){
+    errorHandle('Only a valid VFocus can be passed to mergeIfNecessary, you pased: %s', focus);
+  }
+
+  // Merging is simply a matter of updating the attributes of any notes
+  // where all the segments of the note doesn't have the same timestamp,
+  // or where there's no start or end property (e.g. when the user has deleted
+  // the last note segment of a note).
+
+  findAllNotes(focus)
+  //find any notes that need to be reset
+  .filter(note => {
+
+    //find any inconsistent time stamps
+    var inconsistentTimeStamps = _(note)
+    .map(segment => !!segment.vNode.properties.dataset.noteEditedBy)
+    .uniq()
+    .value();
+
+    if(inconsistentTimeStamps.length > 1){
+      return true;
+    }
+
+    //check for the right data attributes
+    var hasNoteStart = 'noteStart' in note[0].vNode.properties.dataset;
+    var hasNoteEnd = 'noteEnd' in note[note.length - 1].vNode.properties.dataset;
+    return !(hasNoteStart && hasNoteEnd);
+
+  })
+  //reset any resulting notes properties
+  .forEach(note =>{
+    resetNoteSegmentClasses(note);
+  });
+}

--- a/src/actions/noting/merge-if-necessary.js
+++ b/src/actions/noting/merge-if-necessary.js
@@ -27,7 +27,7 @@ var resetNoteSegmentClasses = require('./reset-note-segment-classes');
    */
 module.exports = function mergeIfNecessary(focus){
 
-  if(!isVFocus(focus)){
+  if (!isVFocus(focus)){
     errorHandle('Only a valid VFocus can be passed to mergeIfNecessary, you pased: %s', focus);
   }
 

--- a/src/actions/noting/remove-erroneous-br-tags.js
+++ b/src/actions/noting/remove-erroneous-br-tags.js
@@ -25,7 +25,7 @@ module.exports = function preventBrTags(focus) {
   var markers = findScribeMarkers(focus);
 
   //if we have a selection return
-  if(markers.length === 2 || !markers[0]){
+  if (markers.length === 2 || !markers[0]){
     return;
   }
 
@@ -39,28 +39,28 @@ module.exports = function preventBrTags(focus) {
 
   // Replace/delete empty notes, and parents that might have become empty.
   segments.map(segment => {
-    if(hasOnlyEmptyTexChildren(segment)){
+    if (hasOnlyEmptyTexChildren(segment)){
       // When we delete a space we want to add a space to the previous
       // note segment.
       var prevNoteSegment  = segment.prev().find(isNoteSegment, 'prev');
-      if(prevNoteSegment){
+      if (prevNoteSegment){
         //get the last text node
         var lastTextNode = prevNoteSegment.vNode.children.filter(isVText).slice(-1)[0];
-        if(lastTextNode){
+        if (lastTextNode){
           lastTextNode.text = lastTextNode.text + ' ';
         }
       }
     }
 
-    if(hasNoTextChildren(segment) || hasOnlyEmptyTexChildren(segment)){
+    if (hasNoTextChildren(segment) || hasOnlyEmptyTexChildren(segment)){
       // In Chrome, removing causes text before the note to be deleted when
       // deleting the last note segment. Replacing with an empty node works
       // fine in Chrome and FF.
       var replaced = segment.replace(new VText('\u200B'));
 
       //remove empty ancestor nodes
-      while(replaced){
-        if(!replaced.canDown()){
+      while (replaced){
+        if (!replaced.canDown()){
           replaced.remove();
         }
         replaced = replaced.up();

--- a/src/actions/noting/remove-erroneous-br-tags.js
+++ b/src/actions/noting/remove-erroneous-br-tags.js
@@ -22,7 +22,8 @@ module.exports = function preventBrTags(focus) {
   //
   // Could possibly develop a way of knowing deletions from
   // additions, but this isn't necessary at the moment.
-  var markrs = findScribeMarkers(focus);
+  var markers = findScribeMarkers(focus);
+
   //if we have a selection return
   if(markers.length === 2 || !markers[0]){
     return;
@@ -37,7 +38,7 @@ module.exports = function preventBrTags(focus) {
   ].filter(o => !!o);
 
   // Replace/delete empty notes, and parents that might have become empty.
-  segment.map(segment => {
+  segments.map(segment => {
     if(hasOnlyEmptyTexChildren(segment)){
       // When we delete a space we want to add a space to the previous
       // note segment.
@@ -59,10 +60,10 @@ module.exports = function preventBrTags(focus) {
 
       //remove empty ancestor nodes
       while(replaced){
-        if(!replced.canDown()){
-          replced.remove();
-          replaced = replaced.up();
+        if(!replaced.canDown()){
+          replaced.remove();
         }
+        replaced = replaced.up();
       }
     }
   });

--- a/src/actions/noting/remove-erroneous-br-tags.js
+++ b/src/actions/noting/remove-erroneous-br-tags.js
@@ -1,0 +1,70 @@
+var VText = require('vtree/vtext');
+var isVFocus = require('../../utils/vfocus/is-vfocus');
+var isVText = require('../../utils/vfocus/is-vtext');
+var errorHandle = require('../../utils/error-handle');
+var findScribeMarkers = require('../../utils/noting/find-scribe-markers');
+var isNoteSegment = require('../../utils/noting/is-note-segment');
+var hasOnlyEmptyTexChildren = require('../../utils/vfocus/has-only-empty-text-children');
+var hasNoTextChildren = require('../../utils/vfocus/has-no-text-children');
+
+// In a contenteditable, Scribe currently insert a <BR> tag into empty elements.
+// This causes styling issues when the user deletes a part of a note,
+// e.g. using backspace. This function provides a workaround and should be run
+// anytime a note segment might be empty (as defined by `vdom.consideredEmpty`).
+// TODO: Fix this in Scribe.
+module.exports = function preventBrTags(focus) {
+  if (!isVFocus(focus)) {
+    errorHandle('Only a valid VFocus element can be passed to preventBrTags, you passsed: %s', focus);
+  }
+
+  // We're only interested in when content is removed, meaning
+  // there should only be one marker (a collapsed selection).
+  //
+  // Could possibly develop a way of knowing deletions from
+  // additions, but this isn't necessary at the moment.
+  var markrs = findScribeMarkers(focus);
+  //if we have a selection return
+  if(markers.length === 2 || !markers[0]){
+    return;
+  }
+
+  var marker = markers[0];
+
+  //find the previous and next note segment
+  var segments = [
+    marker.find(isNoteSegment, 'prev'),
+    marker.find(isNoteSegment)
+  ].filter(o => !!o);
+
+  // Replace/delete empty notes, and parents that might have become empty.
+  segment.map(segment => {
+    if(hasOnlyEmptyTexChildren(segment)){
+      // When we delete a space we want to add a space to the previous
+      // note segment.
+      var prevNoteSegment  = segment.prev().find(isNoteSegment, 'prev');
+      if(prevNoteSegment){
+        //get the last text node
+        var lastTextNode = prevNoteSegment.vNode.children.filter(isVText).slice(-1)[0];
+        if(lastTextNode){
+          lastTextNode.text = lastTextNode.text + ' ';
+        }
+      }
+    }
+
+    if(hasNoTextChildren(segment) || hasOnlyEmptyTexChildren(segment)){
+      // In Chrome, removing causes text before the note to be deleted when
+      // deleting the last note segment. Replacing with an empty node works
+      // fine in Chrome and FF.
+      var replaced = segment.replace(new VText('\u200B'));
+
+      //remove empty ancestor nodes
+      while(replaced){
+        if(!replced.canDown()){
+          replced.remove();
+          replaced = replaced.up();
+        }
+      }
+    }
+  });
+
+};

--- a/src/actions/noting/remove-note.js
+++ b/src/actions/noting/remove-note.js
@@ -1,0 +1,38 @@
+var isVFocus = require('../../utils/vfocus/is-vfocus');
+var errorHandle = require('../../utils/error-handle');
+
+var findScribeMarkers = require('../../utils/noting/find-scribe-markers');
+var noteCache = require('../../utils/noting/note-cache');
+var findParentNoteSegment = require('../../utils/noting/find-parent-note-segment');
+var findNoteById = require('../../utils/noting/find-note-by-id');
+var unWrapNote = require('./unwrap-note');
+var ensureNoteIntegrity = require('./ensure-note-integrity');
+
+// treeFocus: tree focus of tree containing two scribe markers
+// Note that we will mutate the tree.
+module.exports = function removeNote(focus){
+
+  if(!isVFocus(focus)){
+    errorHandle('Only a valid VFocus element can be passed to removeNote, you passed: %s', focus);
+  }
+
+  // We assume the caller knows there's only one marker.
+  var marker = findScribeMarkers(focus)[0];
+
+
+  // We can't use findEntireNote here since it'll sometimes give us the wrong result.
+  // See `findEntireNote` documentation. Instead we look the note up by its ID.
+  noteCache.set(focus);
+
+  var note = findParentNoteSegment(marker);
+  var noteSegments = findNoteById(focus, note.vNode.properties.dataset.noteId);
+
+  noteSegments.forEach(unWrapNote);
+
+  ensureNoteIntegrity(focus);
+
+  // The marker is where we want it to be (the same position) so we'll
+  // just leave it.
+  return focus;
+
+};

--- a/src/actions/noting/remove-note.js
+++ b/src/actions/noting/remove-note.js
@@ -12,7 +12,7 @@ var ensureNoteIntegrity = require('./ensure-note-integrity');
 // Note that we will mutate the tree.
 module.exports = function removeNote(focus){
 
-  if(!isVFocus(focus)){
+  if (!isVFocus(focus)){
     errorHandle('Only a valid VFocus element can be passed to removeNote, you passed: %s', focus);
   }
 

--- a/src/actions/noting/remove-part-of-note.js
+++ b/src/actions/noting/remove-part-of-note.js
@@ -41,7 +41,7 @@ var removeEmptyNotes = require('./remove-empty-notes');
 */
 module.exports = function removePartofNote(focus){
 
-  if(!isVFocus(focus)){
+  if (!isVFocus(focus)){
     errorHandle('Only a valid VFocus can be passed to unNotePartOfNote, you passed: %s', focus);
   }
 
@@ -74,7 +74,7 @@ module.exports = function removePartofNote(focus){
   // and/or right of the selection will have been created. We need to update
   // their attributes and CSS classes.
   var onlyPartOfContentsSelected = focusesToNote[0];
-  if(onlyPartOfContentsSelected){
+  if (onlyPartOfContentsSelected){
     ensureNoteIntegrity(onlyPartOfContentsSelected.top());
   }
 

--- a/src/actions/noting/remove-part-of-note.js
+++ b/src/actions/noting/remove-part-of-note.js
@@ -1,0 +1,94 @@
+var _ = require('lodash');
+var VText = require('vtree/vtext');
+
+var isVFocus = require('../../utils/vfocus/is-vfocus');
+var errorHandle = require('../../utils/error-handle');
+var findTextBetweenScribeMarkers = require('../../utils/noting/find-text-between-scribe-markers');
+var findEntireNote = require('../../utils/noting/find-entire-note');
+var flattenTree = require('../../utils/vfocus/flatten-tree');
+var isVText = require('../../utils/vfocus/is-vtext');
+var getNoteDataAttribs = require('../../utils/get-note-data-attrs');
+var wrapInNote = require('./wrap-in-note');
+var unWrapNote = require('./unwrap-note');
+var ensureNoteIntegrity = require('./ensure-note-integrity');
+var findScribeMarkers = require('../../utils/noting/find-scribe-markers');
+var removeEmptyNotes = require('./remove-empty-notes');
+/*
+   Unnote part of note, splitting the rest of the original note into new notes.
+
+   Example
+   -------
+   Text within a note has been selected:
+
+   <p>Asked me questions about the vessel<gu-note>|, the time she left Marseilles|, the
+   course she had taken,</gu-note> and what was her cargo. I believe, if she had not
+   been laden, and I had been her master, he would have bought her.</p>
+
+
+   We find the entire note and, within the note, we note everything _but_ what we want to unnote:
+
+   <p>Asked me questions about the vessel<gu-note>, the time she left Marseilles<gu-note>, the
+   course she had taken,</gu-note></gu-note> and what was her cargo. I believe, if she had not
+   been laden, and I had been her master, he would have bought her.</p>
+
+
+   Then we unwrap the previously existing note. The text we selected has been unnoted:
+
+   <p>Asked me questions about the vessel, the time she left Marseilles<gu-note>, the
+   course she had taken,</gu-note> and what was her cargo. I believe, if she had not
+   been laden, and I had been her master, he would have bought her.</p>
+
+*/
+module.exports = function removePartofNote(focus){
+
+  if(!isVFocus(focus)){
+    errorHandle('Only a valid VFocus can be passed to unNotePartOfNote, you passed: %s', focus);
+  }
+
+  var focusesToUnnote = findTextBetweenScribeMarkers(focus);
+  var entireNote = findEntireNote(focusesToUnnote[0]);
+
+  var entireNoteTextNodeFocuses = _(entireNote).map(flattenTree)
+  .flatten().value().filter(isVText);
+
+  var entireNoteTextNodes = entireNoteTextNodeFocuses.map(nodeFocus => nodeFocus.vNode);
+  var textNodesToUnote = focusesToUnnote.map(nodeFocus => nodeFocus.vNode);
+  var toWrapAndReplace = _.difference(entireNoteTextNodes, textNodesToUnote);
+
+  var focusesToNote = entireNoteTextNodeFocuses.filter(nodeFocus => {
+    return (textNodesToUnote.indexOf(nodeFocus.vNode) === -1)
+  });
+
+  var noteData = getNoteDataAttribs();
+
+  // Wrap the text nodes.
+  var wrappedTextNodes = toWrapAndReplace.map(nodeFocus => wrapInNote(nodeFocus, noteData));
+
+  // Replace the nodes in the tree with the wrapped versions.
+  _.zip(focusesToNote, wrappedTextNodes).forEach(node => node[0].replace(node[1]));
+
+  // Unwrap previously existing note.
+  entireNote.forEach(unWrapNote);
+
+  // Unless the user selected the entire note contents, notes to the left
+  // and/or right of the selection will have been created. We need to update
+  // their attributes and CSS classes.
+  var onlyPartOfContentsSelected = focusesToNote[0];
+  if(onlyPartOfContentsSelected){
+    ensureNoteIntegrity(onlyPartOfContentsSelected.top());
+  }
+
+  // Place marker immediately before the note to the right (this way of doing
+  // that seems to be the most reliable for some reason). Both Chrome and
+  // Firefox have issues with this however. To force them to behave we insert
+  // an empty span element inbetween.
+  var markers = findScribeMarkers(focus.refresh());
+  markers.splice(-1)[0].insertAfter(new VText('\u200B'));
+  markers[0].remove();
+
+  // If the user selected everything but a space (or zero width space), we remove
+  // the remaining note. Most likely that's what our user intended.
+  removeEmptyNotes(focus.refresh());
+
+  return focus;
+};

--- a/src/actions/noting/wrap-in-note.js
+++ b/src/actions/noting/wrap-in-note.js
@@ -1,6 +1,4 @@
-var TAG = 'gu-note';
-var CLASS_NAME = 'note';
-
+var config = require('../../config');
 var _ = require('lodash');
 var h = require('virtual-hyperscript');
 
@@ -8,7 +6,7 @@ var getUKDate = require('../../utils/get-uk-date');
 
 // Wrap in a note.
 // toWrap can be a vNode, DOM node or a string. One or an array with several.
-module.exports = function wrapInNote(focus, data) {
+module.exports = function wrapInNote(focus, data){
 
   var notes = _.isArray(focus) ? focus : [focus];
 
@@ -16,11 +14,8 @@ module.exports = function wrapInNote(focus, data) {
   // https://github.com/guardian/scribe-plugin-noting/issues/45
   data = _.extend({}, (data || {}));
 
-  var tagName = TAG + '.' + CLASS_NAME;
+  var tagName = config.get('tagName') + '.' + config.get('className');
 
-  return h(tagName, {
-    title: getUKDate(data),
-    dataset: data
-  }, notes);
+  return h(tagName, {title: getUKDate(data), dataset: data}, notes);
 
 };

--- a/src/api/note-toggle.js
+++ b/src/api/note-toggle.js
@@ -42,26 +42,7 @@ var updateNoteBarriers = require('../actions/noting/reset-note-barriers');
 var createEmptyNoteAtCaret = require('../actions/noting/create-note-at-caret');
 var preventBrTags = require('../actions/noting/remove-erroneous-br-tags');
 var createNoteFromSelection = require('../actions/noting/create-note-from-selection');
-
-// treeFocus: tree focus of tree containing two scribe markers
-// Note that we will mutate the tree.
-function unnote(treeFocus) {
-  // We assume the caller knows there's only one marker.
-  var marker = vdom.findMarkers(treeFocus)[0];
-  // We can't use findEntireNote here since it'll sometimes give us the wrong result.
-  // See `findEntireNote` documentation. Instead we look the note up by its ID.
-  vdom.updateNotesCache(treeFocus);
-  var noteSegment = vdom.findAncestorNoteSegment(marker);
-  var noteSegments = vdom.findNote(treeFocus, noteSegment.vNode.properties.dataset.noteId);
-
-  noteSegments.forEach(unwrap);
-
-  exports.ensureNoteIntegrity(treeFocus);
-
-  // The marker is where we want it to be (the same position) so we'll
-  // just leave it.
-}
-
+var unnote = require('../actions/noting/remove-note');
 
 /*
 Unnote part of note, splitting the rest of the original note into new notes.
@@ -159,29 +140,6 @@ function unnotePartOfNote(treeFocus) {
   vdom.removeEmptyNotes(treeFocus.refresh());
 
 }
-
-
-/*
-  Example. We have two notes:
-  <p>
-    <gu-note>Some noted text</gu-note>| and some other text inbetween |<gu-note>More noted text</gu-note>
-  </p>
-
-  We press BACKSPACE, deleting the text, and end up with:
-  <p>
-    <gu-note data-note-edited-by="Edmond Dantès" data-note-edited-date="2014-09-15T16:49:20.012Z">Some noted text</gu-note><gu-note data-note-edited-by="Lord Wilmore" data-note-edited-date="2014-09-20T10:00:00.012Z">More noted text</gu-note>
-  </p>
-
-  This function will merge the notes:
-  <p>
-    <gu-note data-note-edited-by="The Count of Monte Cristo" data-note-edited-date="2014-10-10T17:00:00.012Z">Some noted text</gu-note><gu-note data-note-edited-by="The Count of Monte Cristo" data-note-edited-date="2014-10-10T17:00:00.012Z">More noted text</gu-note>
-  </p>
-
-  The last user to edit "wins", the rationale being that they have approved
-  these notes by merging them. In this case all note segments are now
-  listed as being edited by The Count of Monte Cristo and the timestamp
-  shows the time when the notes were merged.
- */
 
 var  mergeIfNecessary = require('../actions/noting/merge-if-necessary');
 var ensureNoteIntegrity = exports.ensureNoteIntegrity = require('../actions/noting/ensure-note-integrity');

--- a/src/api/note-toggle.js
+++ b/src/api/note-toggle.js
@@ -41,85 +41,10 @@ var createNoteBarrier = require('../utils/create-note-barrier');
 var updateNoteBarriers = require('../actions/noting/reset-note-barriers');
 var createEmptyNoteAtCaret = require('../actions/noting/create-note-at-caret');
 var preventBrTags = require('../actions/noting/remove-erroneous-br-tags');
+var createNoteFromSelection = require('../actions/noting/create-note-from-selection');
 
 // treeFocus: tree focus of tree containing two scribe markers
 // Note that we will mutate the tree.
-function createNoteFromSelection(treeFocus) {
-  // We want to wrap text nodes between the markers. We filter out nodes that have
-  // already been wrapped.
-  var toWrapAndReplace = vdom.findTextNodeFocusesBetweenMarkers(treeFocus).filter(vdom.focusOutsideNote);
-
-
-  // Wrap the text nodes.
-  var userAndTime = userAndTimeAsDatasetAttrs();
-  var wrappedTextNodes = toWrapAndReplace.map(function(focus) {
-    return wrapInNote(focus.vNode, userAndTime);
-  });
-
-
-  // Replace the nodes in the tree with the wrapped versions.
-  _.zip(toWrapAndReplace, wrappedTextNodes).forEach(function(focusAndReplacementVNode) {
-    var focus = focusAndReplacementVNode[0];
-    var replacementVNode = focusAndReplacementVNode[1];
-
-    focus.replace(replacementVNode);
-  });
-
-
-  // If we end up with an empty note a <BR> tag would be created. We have to do
-  // this before we remove the markers.
-  preventBrTags(treeFocus);
-
-
-  // We want to place the caret after the note. First we have to remove the
-  // existing markers.
-  vdom.removeVirtualScribeMarkers(treeFocus);
-
-
-  // Update note properties (merges if necessary).
-  var lastNoteSegment = vdom.findLastNoteSegment(toWrapAndReplace[0]);
-
-  var noteSegments = vdom.findEntireNote(lastNoteSegment);
-  updateNoteProperties(noteSegments);
-
-
-  // We need to clear the cache, and this has to be done before we place
-  // our markers or we'll end up placing the cursor inside the note instead
-  // of immediately after it.
-  //
-  // TODO: Revisit our caching strategy to make it less of a "foot gun", or
-  // refactor so that we do less tree traversals and remove the caching.
-  vdom.updateNotesCache(treeFocus);
-
-
-  // Now let's place that caret.
-  var outsideNoteFocus = _.last(noteSegments).find(vdom.focusOutsideNote);
-
-  // We guard against the case when the user notes the last piece of text in a
-  // Scribe instance. In that case we don't bother placing the cursor.
-  // (What behaviour would a user expect?)
-  if (outsideNoteFocus) {
-    if (!vdom.focusOnParagraph(outsideNoteFocus)) {
-      // The user's selection ends within a paragraph.
-
-      // To place a marker we have to place an element inbetween the note barrier
-      // and the marker, or Chrome will place the caret inside the note.
-      outsideNoteFocus.insertBefore([new VText('\u200B'), createVirtualScribeMarker()]);
-
-    } else {
-
-      // The user's selection ends with a whole paragraph being selected. Now
-      // we need to place the caret in a different manner (or we will end up
-      // with a new empty paragraph). So we place the caret at the start of the
-      // next paragraph.
-      var focus = outsideNoteFocus.find(vdom.focusOnNonEmptyTextNode);
-      if (focus) focus.insertBefore(createVirtualScribeMarker());
-    }
-  }
-
-  vdom.removeEmptyNotes(treeFocus);
-}
-
 function unnote(treeFocus) {
   // We assume the caller knows there's only one marker.
   var marker = vdom.findMarkers(treeFocus)[0];

--- a/src/api/note-toggle.js
+++ b/src/api/note-toggle.js
@@ -183,47 +183,8 @@ function unnotePartOfNote(treeFocus) {
   shows the time when the notes were merged.
  */
 
-function mergeIfNecessary(treeFocus) {
-
-  function inconsistentTimestamps(note) {
-    function getDataDate(noteSegment) {
-      return noteSegment.vNode.properties.dataset[DATA_DATE_CAMEL];
-    }
-
-    var uniqVals = _(note).map(getDataDate).uniq().value();
-    return uniqVals.length > 1;
-  }
-
-  function lacksStartOrEnd(note) {
-    var hasNoteStart = 'noteStart' in note[0].vNode.properties.dataset;
-    var hasNoteEnd = 'noteEnd' in note[note.length - 1].vNode.properties.dataset;
-
-    return !(hasNoteStart && hasNoteEnd);
-  }
-
-  // Merging is simply a matter of updating the attributes of any notes
-  // where all the segments of the note doesn't have the same timestamp,
-  // or where there's no start or end property (e.g. when the user has deleted
-  // the last note segment of a note).
-  function criteria(note) {
-    return inconsistentTimestamps(note) || lacksStartOrEnd(note);
-  }
-  vdom.findAllNotes(treeFocus).filter(criteria).forEach(function(note) {
-    note[0].vNode.hasBeenRound = true;
-    updateNoteProperties(note);
-  });
-}
-
-
-
-exports.ensureNoteIntegrity = function(treeFocus) {
-  // cache must be up to date before running this
-  vdom.updateNotesCache(treeFocus);
-  mergeIfNecessary(treeFocus);
-  updateNoteBarriers(treeFocus);
-  preventBrTags(treeFocus);
-};
-
+var  mergeIfNecessary = require('../actions/noting/merge-if-necessary');
+var ensureNoteIntegrity = exports.ensureNoteIntegrity = require('../actions/noting/ensure-note-integrity');
 
 exports.toggleNoteAtSelection = function toggleNoteAtSelection(treeFocus, selection) {
   function state() {

--- a/src/api/note-toggle.js
+++ b/src/api/note-toggle.js
@@ -40,6 +40,7 @@ var createVirtualScribeMarker = require('../utils/create-virtual-scribe-marker')
 var createNoteBarrier = require('../utils/create-note-barrier');
 var updateNoteBarriers = require('../actions/noting/reset-note-barriers');
 var createEmptyNoteAtCaret = require('../actions/noting/create-note-at-caret');
+var preventBrTags = require('../actions/noting/remove-erroneous-br-tags');
 
 // treeFocus: tree focus of tree containing two scribe markers
 // Note that we will mutate the tree.
@@ -288,7 +289,6 @@ function mergeIfNecessary(treeFocus) {
   });
 }
 
-var preventBrTags = require('../actions/noting/remove-erroneous-br-tags');
 
 
 exports.ensureNoteIntegrity = function(treeFocus) {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,7 +4,8 @@ var _ = require('lodash');
 var config = {
   user: 'unknown',
   nodeName: 'GU-NOTE',
-  className: 'gu-note',
+  tagName: 'gu-note',
+  classname: 'note',
   dataName: 'data-note-edited-by',
   dataNameCamel: 'dataNoteEditedBy',
   dataDate: 'data-note-edited-date',

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -5,7 +5,7 @@ var config = {
   user: 'unknown',
   nodeName: 'GU-NOTE',
   tagName: 'gu-note',
-  classname: 'note',
+  className: 'note',
   dataName: 'data-note-edited-by',
   dataNameCamel: 'dataNoteEditedBy',
   dataDate: 'data-note-edited-date',

--- a/src/noting-commands.js
+++ b/src/noting-commands.js
@@ -10,6 +10,8 @@ var noteToggle = require('./api/note-toggle');
 var noteCollapse = require('./api/note-collapse');
 var vdom = require('./noting-vdom');
 var _ = require('lodash');
+var configStore = require('./config');
+
 var scribeSelector;
 
 /**
@@ -21,9 +23,12 @@ exports.init = function(scribe, config) {
   // initialise current user for Noting API
   noteToggle.user = config.user;
 
+
   // initialise scribe element selector
   // TODO: Extract the configuration varialbles into its own module.
   scribeSelector = (config.scribeInstancesSelector || '.scribe');
+
+  configStore.set(config)
 
   scribe.commands.note = createNoteToggleCommand(scribe);
   scribe.commands.noteCollapseToggle = createCollapseToggleCommand(scribe);

--- a/src/utils/noting/find-last-note-segment.js
+++ b/src/utils/noting/find-last-note-segment.js
@@ -1,18 +1,14 @@
-var _ = require('lodash');
 var isVFocus = require('../vfocus/is-vfocus');
 var isWithinNote = require('./is-within-note');
 var isNoteSegment = require('./is-note-segment');
 var errorHandle = require('../error-handle');
 
-module.exports = function findFirstNoteSegment(focus) {
+module.exports = function findLastNoteSegment(focus) {
 
   if (!isVFocus(focus)) {
     errorHandle('only a valid VFocus can be passed to findFirstNoteSegment, you passed: %s', focus);
   }
 
-  return _.last(
-    focus.takeWhile(isWithinNote).filter(isNoteSegment)
-  );
-
+  return focus.takeWhile(isWithinNote).filter(isNoteSegment).splice(-1)[0];
 
 };

--- a/test/integration/create-note.spec.js
+++ b/test/integration/create-note.spec.js
@@ -35,8 +35,11 @@ describe('Creating Scribe Notes', function() {
               // Expect one start and one end attribute
               var numberOfNoteStartAttributes = innerHTML.match(/note--start/g).length;
               var numberOfNoteEndAttributes = innerHTML.match(/note--end/g).length;
+              var numberOfNoteUndefinedElements = innerHTML.match(/undefined/g);
+
               expect(numberOfNoteStartAttributes).to.equal(1);
               expect(numberOfNoteEndAttributes).to.equal(1);
+              expect(numberOfNoteUndefinedElements).to.be.a('null');
 
               expect(innerHTML).to.include('data-note-edited-by');
               expect(innerHTML).to.include('data-note-edited-date');

--- a/test/integration/erroneous-br-tags.spec.js
+++ b/test/integration/erroneous-br-tags.spec.js
@@ -1,0 +1,41 @@
+var chai = require('chai');
+var webdriver = require('selenium-webdriver');
+var helpers = require('scribe-test-harness/helpers');
+var note = require('./helpers/create-note');
+
+var expect = chai.expect;
+
+var when = helpers.when;
+var given = helpers.given;
+var givenContentOf = helpers.givenContentOf;
+
+var scribeNode;
+var driver;
+beforeEach(()=> {
+  scribeNode = helpers.scribeNode;
+  driver = helpers.driver;
+});
+
+describe('Scribes fondness for erroneous <br> tags', ()=>{
+  given('we have a note with at least two segments', ()=>{
+    givenContentOf('<p>|This is a note <em>with</em> m|any segments</p>', ()=> {
+      when('we delete content up to the end of a note segment', ()=>{
+        it('should not produce an erroneous <br> tags', ()=>{
+          note()
+          .then(()=> scribeNode.sendKeys(webdriver.Key.BACK_SPACE))
+          .then(()=> scribeNode.sendKeys(webdriver.Key.BACK_SPACE))
+          //it takes a small amount of time for this bug to become visible
+          //as such we wait here. 1000ms is a TOTAL magic number
+          //but hey, it works.
+          .then(()=> driver.sleep(1000))
+          .then(()=> scribeNode.getInnerHTML())
+          .then((innerHTML)=> {
+            var result = (innerHTML.match(/<br>/g) || []);
+            expect(result.length).to.equal(0);
+          });
+
+        });
+      });
+    });
+  });
+});

--- a/test/unit/actions/noting/create-note-from-selection.spec.js
+++ b/test/unit/actions/noting/create-note-from-selection.spec.js
@@ -1,0 +1,34 @@
+var util = require('util');
+var path = require('path');
+var _ = require('lodash');
+var chai = require('chai');
+var expect = chai.expect;
+
+var h = require('virtual-hyperscript');
+var VText = require('vtree/vtext');
+var VFocus = require(path.resolve(process.cwd(), 'src/vfocus'));
+
+var createNoteFromSelection = require(path.resolve(process.cwd(), 'src/actions/noting/create-note-from-selection'));
+
+describe('createNoteFromSelection()', function() {
+
+  it('should create a note wrapping the selected text', function() {
+
+    var tree = h('p', [
+      h('em.scribe-marker'),
+      new VText('This is some text'),
+      h('em.scribe-marker')
+    ]);
+
+    tree = new VFocus(tree);
+    tree = createNoteFromSelection(tree);
+
+    console.log('-----------------------');
+    console.log(tree);
+    console.log('-----------------------');
+
+    expect(tree.next().vNode.tagName).to.equal('gu-note');
+
+  });
+
+});

--- a/test/unit/actions/noting/create-note-from-selection.spec.js
+++ b/test/unit/actions/noting/create-note-from-selection.spec.js
@@ -10,9 +10,9 @@ var VFocus = require(path.resolve(process.cwd(), 'src/vfocus'));
 
 var createNoteFromSelection = require(path.resolve(process.cwd(), 'src/actions/noting/create-note-from-selection'));
 
-describe('createNoteFromSelection()', function() {
+describe('createNoteFromSelection()', ()=> {
 
-  it('should create a note wrapping the selected text', function() {
+  it('should create a note wrapping the selected text', ()=> {
 
     var tree = h('p', [
       h('em.scribe-marker'),
@@ -27,7 +27,7 @@ describe('createNoteFromSelection()', function() {
 
   });
 
-  it('should create a note wrapping ONLY the selected text', function() {
+  it('should create a note wrapping ONLY the selected text', ()=> {
 
     var tree = h('div', [
       h('p', 'This is some text'),

--- a/test/unit/actions/noting/create-note-from-selection.spec.js
+++ b/test/unit/actions/noting/create-note-from-selection.spec.js
@@ -23,12 +23,28 @@ describe('createNoteFromSelection()', function() {
     tree = new VFocus(tree);
     tree = createNoteFromSelection(tree);
 
-    console.log('-----------------------');
-    console.log(tree);
-    console.log('-----------------------');
-
     expect(tree.next().vNode.tagName).to.equal('gu-note');
 
   });
+
+  it('should create a note wrapping ONLY the selected text', function() {
+
+    var tree = h('div', [
+      h('p', 'This is some text'),
+      h('em.scribe-marker'),
+      h('p', 'This is some text'),
+      h('em.scribe-marker'),
+      h('p', 'This is some text'),
+    ]);
+
+    tree = new VFocus(tree);
+    tree = createNoteFromSelection(tree);
+
+    expect(tree.next().vNode.tagName).not.to.equal('gu-note');
+    expect(tree.next().next().vNode.tagName).not.to.equal('gu-note');
+
+  });
+
+
 
 });

--- a/test/unit/actions/noting/remove-note.spec.js
+++ b/test/unit/actions/noting/remove-note.spec.js
@@ -9,9 +9,9 @@ var VFocus = require(path.resolve(process.cwd(), 'src/vfocus'));
 
 var removeNote = require(path.resolve(process.cwd(), 'src/actions/noting/remove-note'));
 
-describe('removeNote()', function() {
+describe('removeNote()', ()=> {
 
-  it('should remove a note that surrounds the caret', function() {
+  it('should remove a note that surrounds the caret', ()=> {
 
     var tree = h('p', [
       h('gu-note', {dataset: {noteId: 1234}}, [

--- a/test/unit/actions/noting/remove-note.spec.js
+++ b/test/unit/actions/noting/remove-note.spec.js
@@ -1,0 +1,32 @@
+var path = require('path');
+var _ = require('lodash');
+var chai = require('chai');
+var expect = chai.expect;
+
+var h = require('virtual-hyperscript');
+var VText = require('vtree/vtext');
+var VFocus = require(path.resolve(process.cwd(), 'src/vfocus'));
+
+var removeNote = require(path.resolve(process.cwd(), 'src/actions/noting/remove-note'));
+
+describe('removeNote()', function() {
+
+  it('should remove a note that surrounds the caret', function() {
+
+    var tree = h('p', [
+      h('gu-note', {dataset: {noteId: 1234}}, [
+      new VText('this'),
+      new VText('is'),
+      h('em.scribe-marker'),
+      new VText('some'),
+      new VText('text')
+    ])
+    ]);
+
+    tree = new VFocus(tree);
+    tree = removeNote(tree);
+
+    expect(/gu-note/g.test(JSON.stringify(tree))).to.be.false;
+  });
+
+});

--- a/test/unit/actions/noting/remove-part-of-note.spec.js
+++ b/test/unit/actions/noting/remove-part-of-note.spec.js
@@ -1,0 +1,36 @@
+
+var util = require('util');
+var path = require('path');
+var _ = require('lodash');
+var chai = require('chai');
+var expect = chai.expect;
+
+var h = require('virtual-hyperscript');
+var VText = require('vtree/vtext');
+var VFocus = require(path.resolve(process.cwd(), 'src/vfocus'));
+
+var removePartOfNote = require(path.resolve(process.cwd(), 'src/actions/noting/remove-part-of-note'));
+
+describe('removePartNote()', function() {
+
+  it('should remove a note segment that is selected', function() {
+
+    var tree = h('p', [
+      h('gu-note', {dataset: {noteId: 1234}}, [
+      new VText('this'),
+      new VText('is'),
+      h('em.scribe-marker'),
+      new VText('some'),
+      h('em.scribe-marker'),
+      new VText('text')
+    ])
+    ]);
+
+    tree = new VFocus(tree);
+    tree = removePartOfNote(tree);
+
+    expect(JSON.stringify(tree).match(/gu-note/g).length).to.be.equal(3);
+
+  });
+
+});

--- a/test/unit/actions/noting/remove-part-of-note.spec.js
+++ b/test/unit/actions/noting/remove-part-of-note.spec.js
@@ -11,9 +11,9 @@ var VFocus = require(path.resolve(process.cwd(), 'src/vfocus'));
 
 var removePartOfNote = require(path.resolve(process.cwd(), 'src/actions/noting/remove-part-of-note'));
 
-describe('removePartNote()', function() {
+describe('removePartNote()', ()=> {
 
-  it('should remove a note segment that is selected', function() {
+  it('should remove a note segment that is selected', ()=> {
 
     var tree = h('p', [
       h('gu-note', {dataset: {noteId: 1234}}, [

--- a/test/unit/actions/noting/toggle-all-note-collapse-state.spec.js
+++ b/test/unit/actions/noting/toggle-all-note-collapse-state.spec.js
@@ -11,7 +11,7 @@ var hasClass = require(path.resolve(process.cwd(), 'src/utils/vdom/has-class'));
 
 describe('toggleAllNoteCollapseState()', function() {
 
-  it('should toggle a class only on selected notes', function() {
+  it('should toggle a class only on selected notes',  function(){
 
     var firstNote = h('gu-note');
     var secondNote = h('gu-note', [

--- a/test/unit/actions/noting/toggle-all-note-collapse-state.spec.js
+++ b/test/unit/actions/noting/toggle-all-note-collapse-state.spec.js
@@ -11,7 +11,7 @@ var hasClass = require(path.resolve(process.cwd(), 'src/utils/vdom/has-class'));
 
 describe('toggleAllNoteCollapseState()', function() {
 
-  it('should toggle a class only on selected notes',  function(){
+  it('should toggle a class only on selected notes', function(){
 
     var firstNote = h('gu-note');
     var secondNote = h('gu-note', [


### PR DESCRIPTION
This PR completes the `note-toggle` refactoring.

### QA
- Test un-note part of a note. Make a selection within a note and hit F10
- Test un-note a whole note. Drop the caret within a note and hit F10