### PR TITLE
Jscs style guide

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,20 +1,17 @@
 {
   "disallowKeywordsOnNewLine": ["else", "else if"],
-  "disallowMultipleVarDecl": true,
   "disallowNewlineBeforeBlockStatements": true,
-  "disallowPaddingNewlinesInBlocks": true,
   "disallowSpaceAfterObjectKeys": true,
   "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~", "!"],
   "disallowSpacesInCallExpression": true,
   "disallowSpacesInFunctionExpression": {
-      "beforeOpeningRoundBrace": true,
-      "beforeOpeningCurlyBrace": true
+      "beforeOpeningRoundBrace": true
   },
   "disallowSpacesInsideParentheses": true,
   "disallowTrailingComma": true,
   "disallowTrailingWhitespace": true,
   "requireBlocksOnNewline": true,
-  "maximumLineLength": 80,
+  "maximumLineLength": 95,
   "requireCapitalizedConstructors": true,
   "requireCommaBeforeLineBreak": true,
   "requireCurlyBraces": [
@@ -43,7 +40,6 @@
   ],
   "requireSpaceBeforeBinaryOperators": [
     "=",
-    ",",
     "+",
     "-",
     "/",
@@ -66,8 +62,7 @@
     "while",
     "with",
     "return",
-    "typeof",
-    "function"
+    "typeof"
   ],
   "requireSpaceBeforeKeywords": [
     "else",
@@ -77,7 +72,6 @@
   "requireSpaceBeforeBlockStatements": true,
   "requireSpaceBeforeObjectValues": true,
   "requireSpaceBetweenArguments": true,
-  "requireSpacesInForStatement": true,
-  "validateIndentation": "2",
+  "validateIndentation": 2,
   "validateParameterSeparator": ", "
 }

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,83 @@
+{
+  "disallowKeywordsOnNewLine": ["else", "else if"],
+  "disallowMultipleVarDecl": true,
+  "disallowNewlineBeforeBlockStatements": true,
+  "disallowPaddingNewlinesInBlocks": true,
+  "disallowSpaceAfterObjectKeys": true,
+  "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~", "!"],
+  "disallowSpacesInCallExpression": true,
+  "disallowSpacesInFunctionExpression": {
+      "beforeOpeningRoundBrace": true,
+      "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInsideParentheses": true,
+  "disallowTrailingComma": true,
+  "disallowTrailingWhitespace": true,
+  "requireBlocksOnNewline": true,
+  "maximumLineLength": 80,
+  "requireCapitalizedConstructors": true,
+  "requireCommaBeforeLineBreak": true,
+  "requireCurlyBraces": [
+      "if",
+      "else",
+      "for",
+      "while",
+      "do",
+      "try",
+      "catch",
+      "case",
+      "default"
+  ],
+  "requireLineBreakAfterVariableAssignment": true,
+  "requireSpaceAfterBinaryOperators": [
+    "=",
+    ",",
+    "+",
+    "-",
+    "/",
+    "*",
+    "==",
+    "===",
+    "!=",
+    "!=="
+  ],
+  "requireSpaceBeforeBinaryOperators": [
+    "=",
+    ",",
+    "+",
+    "-",
+    "/",
+    "*",
+    "==",
+    "===",
+    "!=",
+    "!=="
+  ],
+  "requireSpaceAfterKeywords": [
+    "do",
+    "for",
+    "if",
+    "else",
+    "switch",
+    "case",
+    "try",
+    "catch",
+    "void",
+    "while",
+    "with",
+    "return",
+    "typeof",
+    "function"
+  ],
+  "requireSpaceBeforeKeywords": [
+    "else",
+    "while",
+    "catch"
+  ],
+  "requireSpaceBeforeBlockStatements": true,
+  "requireSpaceBeforeObjectValues": true,
+  "requireSpaceBetweenArguments": true,
+  "requireSpacesInForStatement": true,
+  "validateIndentation": "2",
+  "validateParameterSeparator": ", "
+}


### PR DESCRIPTION
This PR adds a JSCS configuration file with a set of validation rules that define our code style guide.
You can [run JSCS](http://jscs.info/overview.html) by command line or use it through a linter plugin which depends from the text editor/IDE in use.

**TEST**
Unit tests should pass as usual but there's nothing to test in particular. To check whether JSCS its working in your local environment you should break one of the rules in a .js file and run JSCS against that file. Then JSCS should output this error.