### PR TITLE
Fix place caret bug

### DIFF
--- a/src/actions/noting/create-note-from-selection.js
+++ b/src/actions/noting/create-note-from-selection.js
@@ -68,7 +68,7 @@ module.exports = function createNoteFromSelection(focus){
   // Scribe instance. In that case we don't bother placing the cursor.
   // (What behaviour would a user expect?)
   if (outsideNoteFocus){
-    if (isParagraph(outsideNoteFocus)){
+    if (!isParagraph(outsideNoteFocus)){
       // The user's selection ends within a paragraph.
       // To place a marker we have to place an element inbetween the note barrier
       // and the marker, or Chrome will place the caret inside the note.


### PR DESCRIPTION
In master (right now), when you create a note from selection the caret is placed inside of the new note.  This is not the expected behaviour. This PR fixes this bug so that the caret is now placed directly after the new note.  There are no integration tests for this as when you ask scribe to place some markers, the marker appears outside of the note which is contrary to the actual behaviour.