### PR TITLE
Added check to NoteController.note() for the lack of markers

### DIFF
--- a/src/generate-note-controller.js
+++ b/src/generate-note-controller.js
@@ -100,6 +100,9 @@ module.exports = function(scribe, attrs){
       mutateScribe(scribe, (focus, selection) => {
         //figure out what kind of selection we have
         var markers = findScribeMarkers(focus);
+        if(markers.length <= 0){
+          return;
+        }
         var selectionIsCollapsed = (markers.length === 1);
         var isWithinNote = isSelectionWithinNote(markers);
 


### PR DESCRIPTION
In an effort to fix https://github.com/guardian/scribe-plugin-noting/issues/75 I noticed that multiple scribe instances were placing markers within the current focused scribe element.  As such you may get five sets of `<em class="scribe-marker"></em>` when there are five scribe elements within a page. 

https://github.com/guardian/scribe/pull/324 fixes this but leaves us in the position where an unfocused scribe instance will trigger `NoteController.note()` with no markers within it's element. This PR fixes any negative effects and stops errors being thrown by returning from `note()` if no markers are present.