### PR TITLE
Fix collapse/expand all notes (within multiple scribe instances)

### DIFF
--- a/scribe-plugin-noting.js
+++ b/scribe-plugin-noting.js
@@ -3,8 +3,6 @@ var generateNoteController = require('./src/generate-note-controller');
 var NoteCommandFactory = require('./src/note-command-factory');
 var config = require('./src/config');
 
-var hasAddedCommands = false;
-
 // config, example:
 // { user: 'Firstname Lastname',
 //   scribeInstancesSelector: '.ui-rich-text-editor__input' }
@@ -16,7 +14,6 @@ module.exports = function(attrs) {
     config.get('selectors').forEach(selector => {
       NoteCommandFactory(scribe, selector.commandName, selector.tagName);
     });
-    hasAddedCommands = true;
     generateNoteController(scribe);
   };
 };

--- a/scribe-plugin-noting.js
+++ b/scribe-plugin-noting.js
@@ -1,12 +1,22 @@
 // Scribe noting plugin
 var generateNoteController = require('./src/generate-note-controller');
+var NoteCommandFactory = require('./src/note-command-factory');
+var config = require('./src/config');
 
+var hasAddedCommands = false;
 
 // config, example:
 // { user: 'Firstname Lastname',
 //   scribeInstancesSelector: '.ui-rich-text-editor__input' }
-module.exports = function(config) {
+module.exports = function(attrs) {
+
+  config.set(attrs)
+
   return function(scribe) {
-    generateNoteController(scribe, config);
+    config.get('selectors').forEach(selector => {
+      NoteCommandFactory(scribe, selector.commandName, selector.tagName);
+    });
+    hasAddedCommands = true;
+    generateNoteController(scribe);
   };
 };

--- a/src/actions/noting/toggle-note-classes.js
+++ b/src/actions/noting/toggle-note-classes.js
@@ -23,7 +23,6 @@ module.exports = function toggleNoteClasses(notes, className) {
     //if we have more than one note then we want them all to share state
     var state = collapseState.get();
     state ? action = removeClass : action = addClass;
-    collapseState.set(!state);
   }
 
   notes.forEach(function(vNode) {

--- a/src/generate-note-controller.js
+++ b/src/generate-note-controller.js
@@ -20,17 +20,24 @@ var notingVDom = require('./noting-vdom');
 var mutate = notingVDom.mutate;
 var mutateScribe = notingVDom.mutateScribe;
 
-module.exports = function(scribe, attrs){
+//setup a listener for toggling ALL notes
+// This command is a bit special in the sense that it will operate on all
+// Scribe instances on the page.
+emitter.on('command:toggle:all-notes', tag => {
+  var state = !!noteCollapseState.get();
+  var scribeInstances = document.querySelectorAll(config.get('scribeInstanceSelector'));
+  scribeInstances = _.toArray(scribeInstances);
+  scribeInstances.forEach(instance => {
+    mutate(instance, focus => toggleAllNoteCollapseState(focus));
+  });
+  noteCollapseState.set(!state);
+});
+
+
+module.exports = function(scribe){
 
   class NoteController {
     constructor() {
-
-      //setup the config
-      config.set(attrs);
-
-      config.get('selectors').forEach(selector => {
-        NoteCommandFactory(scribe, selector.commandName, selector.tagName);
-      });
 
       //browser events
       scribe.el.addEventListener('keydown', e => this.onNoteKeyAction(e));
@@ -40,7 +47,6 @@ module.exports = function(scribe, attrs){
       //scribe command events
       emitter.on('command:note', tag => this.note(tag));
       emitter.on('command:toggle:single-note', tag => this.toggleSelectedNotes(tag));
-      emitter.on('command:toggle:all-notes', tag => this.toggleAllNotes(tag));
     }
 
 
@@ -129,17 +135,6 @@ module.exports = function(scribe, attrs){
     //toggleAllNotes will collapse or expand all (or a selected) note
     toggleSelectedNotes() {
       mutateScribe(scribe, (focus)=> toggleSelectedNoteCollapseState(focus));
-    }
-
-    // This command is a bit special in the sense that it will operate on all
-    // Scribe instances on the page.
-    toggleAllNotes() {
-      var state = !!noteCollapseState.get();
-      var scribeInstances = document.querySelectorAll(config.get('scribeInstanceSelector'));
-      scribeInstances = _.toArray(scribeInstances);
-      scribeInstances.forEach(instance => {
-        mutate(instance, focus => toggleAllNoteCollapseState(focus));
-      });
     }
 
     //validateNotes makes sure all note--start note--end and data attributes are in place

--- a/test/unit/actions/noting/toggle-note-classes.spec.js
+++ b/test/unit/actions/noting/toggle-note-classes.spec.js
@@ -27,6 +27,7 @@ describe('toggleClass()', function() {
       expect(note.properties.className).to.equal('my-class');
     });
 
+    collapseState.set(true);
     toggleNoteClasses(notes, 'my-class');
 
     notes.forEach(function(note) {


### PR DESCRIPTION
This PR fixes collapse/expand errors when notes are within multiple scribe instances.  This is due to multiple events being registered to `'command:toggle:all-notes'` which then register a change of `noteCollapseState`.

### QA
- Really difficult to achieve see: https://github.com/guardian/scribe-plugin-noting/issues/82