### PR TITLE
Place caret when the selection ends at the end of a paragraph.

### DIFF
--- a/src/actions/noting/create-note-from-selection.js
+++ b/src/actions/noting/create-note-from-selection.js
@@ -85,8 +85,6 @@ module.exports = function createNoteFromSelection(focus, tagName = config.get('d
   // Scribe instance. In that case we don't bother placing the cursor.
   // (What behaviour would a user expect?)
   if (outsideNoteFocus) {
-
-
     if (!isParagraph(outsideNoteFocus)) {
       // The user's selection ends within a paragraph.
       // To place a marker we have to place an element inbetween the note barrier

--- a/src/actions/noting/create-note-from-selection.js
+++ b/src/actions/noting/create-note-from-selection.js
@@ -18,17 +18,19 @@ var isParagraph = require('../../utils/vfocus/is-paragraph');
 var createVirtualScribeMarker = require('../../utils/create-virtual-scribe-marker');
 var isNotEmpty = require('../../utils/vfocus/is-not-empty');
 var removeEmptyNotes = require('../../actions/noting/remove-empty-notes');
+var findScribeMarkers = require('../../utils/noting/find-scribe-markers');
+var hasClass = require('../../utils/vdom/has-class');
 
 // treeFocus: tree focus of tree containing two scribe markers
 // Note that we will mutate the tree.
-module.exports = function createNoteFromSelection(focus, tagName = config.get('defaultTagName')){
+module.exports = function createNoteFromSelection(focus, tagName = config.get('defaultTagName')) {
 
-  if (!isVFocus(focus)){
+  if (!isVFocus(focus)) {
     errorHandle('Only a valid VFocus element can be passed to createNoteFromSelection, you passed: %s', focus);
   }
   // We want to wrap text nodes between the markers. We filter out nodes that have
   // already been wrapped.
-  var toWrapAndReplace = findTextBetweenScribeMarkers(focus).filter((node)=> isNotWithinNote(node, tagName));
+  var toWrapAndReplace = findTextBetweenScribeMarkers(focus).filter((node) => isNotWithinNote(node, tagName));
 
   //wrap text nodes
   var noteDataSet = getNoteDataAttributes();
@@ -45,10 +47,6 @@ module.exports = function createNoteFromSelection(focus, tagName = config.get('d
   // this before we remove the markers.
   removeErroneousBrTags(focus, tagName);
 
-  // We want to place the caret after the note. First we have to remove the
-  // existing markers.
-  removeScribeMarkers(focus);
-
   // Update note properties (merges if necessary).
   var lastNoteSegment = findLastNoteSegment(toWrapAndReplace[0], tagName);
   var noteSegments = findEntireNote(lastNoteSegment, tagName);
@@ -63,13 +61,33 @@ module.exports = function createNoteFromSelection(focus, tagName = config.get('d
   notesCache.set(focus);
 
   // Now let's place that caret.
-  var outsideNoteFocus = noteSegments.splice(-1)[0].find((node)=> isNotWithinNote(node, tagName));
+  var firstNoteSegment = noteSegments.splice(-1)[0];
+  var outsideNoteFocus = firstNoteSegment.find((node) => isNotWithinNote(node, tagName));
+
+  //we need to detect if the current selection spans to the END of the current paragraph
+  var containingParagraph = firstNoteSegment.find(isParagraph, 'prev');
+  var selectionIsAtEndOfParagraph = hasClass(containingParagraph && containingParagraph.children().slice(-1)[0], 'scribe-marker');
+
+  // We want to place the caret after the note. First we have to remove the
+  // existing markers.
+  removeScribeMarkers(focus);
+
+  //if the current selection ENDS at the END of a paragraph
+  //we need to place the caret at the end of the paragraph OUTSIDE of the note
+  if (selectionIsAtEndOfParagraph) {
+    containingParagraph.addChild(new VText('\u200B'));
+    containingParagraph.addChild(createVirtualScribeMarker());
+    return focus;
+  }
+
 
   // We guard against the case when the user notes the last piece of text in a
   // Scribe instance. In that case we don't bother placing the cursor.
   // (What behaviour would a user expect?)
-  if (outsideNoteFocus){
-    if (!isParagraph(outsideNoteFocus)){
+  if (outsideNoteFocus) {
+
+
+    if (!isParagraph(outsideNoteFocus)) {
       // The user's selection ends within a paragraph.
       // To place a marker we have to place an element inbetween the note barrier
       // and the marker, or Chrome will place the caret inside the note.
@@ -82,7 +100,7 @@ module.exports = function createNoteFromSelection(focus, tagName = config.get('d
       // next paragraph.
 
       var firstNodeWithChildren = outsideNoteFocus.find(isNotEmpty);
-      if (firstNodeWithChildren){
+      if (firstNodeWithChildren) {
         firstNodeWithChildren.insertBefore(createVirtualScribeMarker());
       }
 

--- a/src/vfocus.js
+++ b/src/vfocus.js
@@ -292,3 +292,7 @@ VFocus.prototype.find = function(predicate, movement) {
 
   return focus;
 };
+
+VFocus.prototype.children = function(){
+  return this.vNode.children;
+};

--- a/src/vfocus.js
+++ b/src/vfocus.js
@@ -296,3 +296,7 @@ VFocus.prototype.find = function(predicate, movement) {
 VFocus.prototype.children = function(){
   return this.vNode.children;
 };
+
+VFocus.prototype.addChild = function(child){
+  this.vNode.children.push(child);
+};

--- a/test/integration/caret-position-after-note-whole-paragraph.spec.js
+++ b/test/integration/caret-position-after-note-whole-paragraph.spec.js
@@ -1,0 +1,42 @@
+var chai = require('chai');
+var webdriver = require('selenium-webdriver');
+var helpers = require('scribe-test-harness/helpers');
+var note = require('./helpers/create-note');
+
+var expect = chai.expect;
+
+var when = helpers.when;
+var given = helpers.given;
+var givenContentOf = helpers.givenContentOf;
+
+var scribeNode;
+var driver;
+beforeEach(()=> {
+  scribeNode = helpers.scribeNode;
+  driver = helpers.driver;
+});
+
+
+var note = require('./helpers/create-note');
+
+//when noting the contents of a paragraph a zero width space is added to the NEXT element
+//this space should be added after the note but before the end of the paragraph
+//see: https://github.com/guardian/scribe-plugin-noting/issues/85
+describe('Caret position after noting a paragraph', ()=>{
+  given('we have a selection within a note', ()=>{
+    givenContentOf('<p>|This is some content|</p><p>This is some more content</p>', ()=> {
+      when('we create a note', ()=>{
+        it.only('should place the caret outside of the collapsed note', ()=> {
+
+          note()
+          .then(()=> scribeNode.sendKeys('test'))
+          .then(()=> scribeNode.getInnerHTML())
+          .then((html)=> {
+            expect(html).not.to.include('<p>\u200Btest');
+            expect(html).not.to.include('<p>\u200BThis');
+          })
+        });
+      });
+    });
+  });
+});

--- a/test/integration/caret-position-after-note-whole-paragraph.spec.js
+++ b/test/integration/caret-position-after-note-whole-paragraph.spec.js
@@ -26,7 +26,7 @@ describe('Caret position after noting a paragraph', ()=>{
   given('we have a selection within a note', ()=>{
     givenContentOf('<p>|This is some content|</p><p>This is some more content</p>', ()=> {
       when('we create a note', ()=>{
-        it.only('should place the caret outside of the collapsed note', ()=> {
+        it('should place the caret outside of the collapsed note', ()=> {
 
           note()
           .then(()=> scribeNode.sendKeys('test'))
@@ -35,6 +35,17 @@ describe('Caret position after noting a paragraph', ()=>{
             expect(html).not.to.include('<p>\u200Btest');
             expect(html).not.to.include('<p>\u200BThis');
           })
+          .then(()=> {
+            return driver.executeScript(function(){
+              var s = new scribe.api.Selection();
+              s.placeMarkers();
+            });
+          })
+          .then(()=> scribeNode.getInnerHTML())
+          .then((html)=> {
+            expect(html).to.include('</em></p>');
+          });
+
         });
       });
     });


### PR DESCRIPTION
This PR fixes https://github.com/guardian/scribe-plugin-noting/issues/86 & https://github.com/guardian/scribe-plugin-noting/issues/85

### QA
- Select all text up to the end of a paragraph. Create a note. Ensure the caret is placed after the new note and NOT within any paragraphs below.