### PR TITLE
Fix Issue 86

### DIFF
--- a/src/actions/noting/reset-note-barriers.js
+++ b/src/actions/noting/reset-note-barriers.js
@@ -26,16 +26,22 @@ module.exports = function resetNoteBarriers(focus, tagName = config.get('default
   findAllNotes(focus, tagName).forEach(noteSegments => {
     //first note
     noteSegments[0].next().insertBefore(createNoteBarrier());
+
+
     //last note
     // This is necessarily complex (been through a few iterations) because
     // of Chrome's lack of flexibility when it comes to placing the caret.
     var lastNote = noteSegments.slice(-1)[0].find((node)=> isNotWithinNote(node, tagName));
     //find the first non-empty text node after the note
     var adjacentTextNode = lastNote && lastNote.find(isNotEmpty);
+    var adjacentTextNodeContainsOnlyLink = adjacentTextNode && adjacentTextNode.vNode.text && !!adjacentTextNode.vNode.text.match(/^https?:\/\//);
 
-    if(adjacentTextNode){
+    if(adjacentTextNodeContainsOnlyLink){
+      adjacentTextNode.parent.addChild(new VText('\u200B'))
+    } else if (adjacentTextNode){
       adjacentTextNode.vNode.text = '\u200B' + adjacentTextNode.vNode.text;
     }
+
   });
 
 

--- a/test/integration/caret-position-after-note-whole-paragraph.spec.js
+++ b/test/integration/caret-position-after-note-whole-paragraph.spec.js
@@ -52,10 +52,13 @@ describe('Caret position after noting a paragraph', ()=>{
     });
   });
 
+  //when a note is created at the end of a paragraph and the next paragraph ONLY contains a link
+  //composer can't call up an embed as a zero width space is added to the beginning
+  //see: https://github.com/guardian/scribe-plugin-noting/issues/86
  given('we have a selection within a note', ()=>{
-    givenContentOf('<p>|This is some content|</p><p>This is some more content</p>', ()=> {
+    givenContentOf('<p>|This is some content|</p><p>https://github.com/guardian/scribe-plugin-noting/issues/86</p>', ()=> {
       when('we create a note and the add a return', ()=>{
-        it.only('should place the caret outside of the collapsed note', ()=> {
+        it('should place the caret outside of the collapsed note', ()=> {
 
           note()
           .then(()=> scribeNode.sendKeys(webdriver.Key.ENTER))

--- a/test/integration/caret-position-after-note-whole-paragraph.spec.js
+++ b/test/integration/caret-position-after-note-whole-paragraph.spec.js
@@ -23,9 +23,10 @@ var note = require('./helpers/create-note');
 //this space should be added after the note but before the end of the paragraph
 //see: https://github.com/guardian/scribe-plugin-noting/issues/85
 describe('Caret position after noting a paragraph', ()=>{
+
   given('we have a selection within a note', ()=>{
     givenContentOf('<p>|This is some content|</p><p>This is some more content</p>', ()=> {
-      when('we create a note', ()=>{
+      when('we create a note and then add some text', ()=>{
         it('should place the caret outside of the collapsed note', ()=> {
 
           note()
@@ -50,4 +51,23 @@ describe('Caret position after noting a paragraph', ()=>{
       });
     });
   });
+
+ given('we have a selection within a note', ()=>{
+    givenContentOf('<p>|This is some content|</p><p>This is some more content</p>', ()=> {
+      when('we create a note and the add a return', ()=>{
+        it.only('should place the caret outside of the collapsed note', ()=> {
+
+          note()
+          .then(()=> scribeNode.sendKeys(webdriver.Key.ENTER))
+          .then(()=> scribeNode.getInnerHTML())
+          .then((html)=> {
+            expect(html).not.to.include('<p>\u200BThis');
+          });
+
+        });
+      });
+    });
+  });
+
+
 });

--- a/test/integration/caret-position-after-note-whole-paragraph.spec.js
+++ b/test/integration/caret-position-after-note-whole-paragraph.spec.js
@@ -58,7 +58,7 @@ describe('Caret position after noting a paragraph', ()=>{
  given('we have a selection within a note', ()=>{
     givenContentOf('<p>|This is some content|</p><p>https://github.com/guardian/scribe-plugin-noting/issues/86</p>', ()=> {
       when('we create a note and the add a return', ()=>{
-        it('should place the caret outside of the collapsed note', ()=> {
+        it('should not add a zero width space to an adjacent text node which starts with a url', ()=> {
 
           note()
           .then(()=> scribeNode.sendKeys(webdriver.Key.ENTER))


### PR DESCRIPTION
Adding spaces to notes which run to the end of the paragraph is not enough to fix https://github.com/guardian/scribe-plugin-noting/issues/86. As such I've added a further e2e test and a check to ensure we never add a zero width space to text node adjacent to a note which starts with a url.