### PR TITLE
Select whole note tweak

### DIFF
--- a/src/generate-note-controller.js
+++ b/src/generate-note-controller.js
@@ -227,7 +227,10 @@ module.exports = function(scribe){
 
         //check that the selection is within a note
         var selector = _.find(config.get('selectors'), (selector) => {
-          return isSelectionEntirelyWithinNote(markers, selector.tagName);
+          // isSelectionWithinNote rather than isSelectionEntirelyWithinNote
+          // since we want to allow all clicks within a note, even if it
+          // selects the note and some text to the left or right of the note.
+          return isSelectionWithinNote(markers, selector.tagName);
         });
 
         //if the selection is within a note select that note


### PR DESCRIPTION
Select whole note wasn't working when a doubleclick would select the note and some more text to the left or right of the note.