### PR TITLE
Tweaks to get around 2 FF issues

### DIFF
--- a/src/generate-note-controller.js
+++ b/src/generate-note-controller.js
@@ -129,7 +129,7 @@ module.exports = function(scribe){
     onElementClicked(e) {
 
       //selecting whole notes
-      if (e.metaKey) {
+      if (e.metaKey || e.ctrlKey) {
         this.selectNote();
       }
 

--- a/src/generate-note-controller.js
+++ b/src/generate-note-controller.js
@@ -95,8 +95,11 @@ module.exports = function(scribe){
         });
       }
 
-      //selecting notes
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.keyCode === 65){
+      // selecting notes (CTRL/META + SHIFT + A)
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.keyCode === 65) {
+        // e.g. Firefox uses this keyboard combination to open the Add-ons Manager.
+        e.preventDefault();
+
         this.selectNote();
       }
 
@@ -126,7 +129,7 @@ module.exports = function(scribe){
     onElementClicked(e) {
 
       //selecting whole notes
-      if (e.detail === 2) {
+      if (e.metaKey) {
         this.selectNote();
       }
 


### PR DESCRIPTION
Solves https://github.com/guardian/scribe-plugin-noting/issues/125
And https://github.com/guardian/flexible-content/pull/1613#issuecomment-83523034

Doubleclick within a note selects the entire paragraph in Firefox, which means we're unable to know which note the user wants to select.

Now you can select an entire note by:
- `CMD/CTRL+SHIFT+A` (just like before)
- `CMD+CLICK` (this one replaces the doubleclick)

/cc @alastairjardine