### PR TITLE
Fix VFocus prev()

### DIFF
--- a/src/vfocus.js
+++ b/src/vfocus.js
@@ -83,27 +83,16 @@ VFocus.prototype.next = function() {
 
 // Focus previous (pre-order)
 VFocus.prototype.prev = function() {
-  function downFurthestRight(vFocus) {
-    function furthestRight(vFocus) {
-      var focus = vFocus;
-      while (focus.canRight()) { focus = focus.right(); }
-      return focus;
+  function downRightmostLoop(focus) {
+    var f = focus;
+    while (f && f.canDown()) {
+        f = f.down().rightmost();
     }
-
-    return vFocus.canDown() ? downFurthestRight(vFocus.down()) : furthestRight(vFocus);
+    return f;
   }
 
-  var focus;
-  if (this.left() && this.left().down()) {
-    focus = downFurthestRight(this.left());
-  } else if (this.left()) {
-    focus = this.left();
-  } else {
-    focus = this.up();
-  }
-
-  return focus;
-};
+  return downRightmostLoop(this.left()) || this.left() || this.up();
+}
 
 // Focus first child
 VFocus.prototype.down = function() {
@@ -124,6 +113,13 @@ VFocus.prototype.right = function() {
   if (! this.canRight()) return null;
 
   return new VFocus(this.rightVNode(), this.parent);
+};
+
+VFocus.prototype.rightmost = function() {
+  var siblingVNodes = this.up().vNode.children;
+  var lastSiblingVNode = siblingVNodes[siblingVNodes.length - 1];
+
+  return new VFocus(lastSiblingVNode, this.parent);
 };
 
 // Focus node to the left (on the same level)

--- a/test/unit/vfocus/movements.spec.js
+++ b/test/unit/vfocus/movements.spec.js
@@ -94,28 +94,31 @@ describe('VFocus - Movements', function() {
 
   });
 
-  describe('rightmost()', function() {
+  describe.only('rightmost()', function() {
 
-    var rightTreeFocus, firstSiblingFocus, lastSiblingFocus;
+    var rightTreeFocus, leftmostSiblingFocus, rightmostSiblingFocus;
     beforeEach(function() {
-      var firstSibling = h('p#first');
-      var lastSibling = h('p#last');
+      var leftmostSibling = h('p#first');
+      var rightmostSibling = h('p#last');
 
       var rightTree = h('div', [
-        firstSibling,
+        leftmostSibling,
         h('p#middle'),
-        lastSibling
+        rightmostSibling
       ]);
 
       rightTreeFocus = new VFocus(rightTree);
-      firstSiblingFocus = rightTreeFocus.down();
-      lastSiblingFocus = firstSiblingFocus.right().right();
+      leftmostSiblingFocus = rightTreeFocus.down();
+      rightmostSiblingFocus = leftmostSiblingFocus.right().right();
     });
 
 
-    it('always focuses the rightmost node', function() {
-      expect(firstSiblingFocus.rightmost().vNode).to.equal(lastSiblingFocus.vNode);
-      expect(lastSiblingFocus.rightmost().vNode).to.equal(lastSiblingFocus.vNode);
+    it('focuses the rightmost node when focusing on a sibling', function() {
+      expect(leftmostSiblingFocus.rightmost().vNode).to.equal(rightmostSiblingFocus.vNode);
+    });
+
+    it('focuses the rightmost node when already focusing on the rightmost node', function() {
+      expect(rightmostSiblingFocus.rightmost().vNode).to.equal(rightmostSiblingFocus.vNode);
     });
 
   });

--- a/test/unit/vfocus/movements.spec.js
+++ b/test/unit/vfocus/movements.spec.js
@@ -94,7 +94,7 @@ describe('VFocus - Movements', function() {
 
   });
 
-  describe.only('rightmost()', function() {
+  describe('rightmost()', function() {
 
     var rightTreeFocus, leftmostSiblingFocus, rightmostSiblingFocus;
     beforeEach(function() {

--- a/test/unit/vfocus/movements.spec.js
+++ b/test/unit/vfocus/movements.spec.js
@@ -94,6 +94,32 @@ describe('VFocus - Movements', function() {
 
   });
 
+  describe('rightmost()', function() {
+
+    var rightTreeFocus, firstSiblingFocus, lastSiblingFocus;
+    beforeEach(function() {
+      var firstSibling = h('p#first');
+      var lastSibling = h('p#last');
+
+      var rightTree = h('div', [
+        firstSibling,
+        h('p#middle'),
+        lastSibling
+      ]);
+
+      rightTreeFocus = new VFocus(rightTree);
+      firstSiblingFocus = rightTreeFocus.down();
+      lastSiblingFocus = firstSiblingFocus.right().right();
+    });
+
+
+    it('always focuses the rightmost node', function() {
+      expect(firstSiblingFocus.rightmost().vNode).to.equal(lastSiblingFocus.vNode);
+      expect(lastSiblingFocus.rightmost().vNode).to.equal(lastSiblingFocus.vNode);
+    });
+
+  });
+
 
   describe('left()', function() {
 

--- a/test/unit/vfocus/movements.spec.js
+++ b/test/unit/vfocus/movements.spec.js
@@ -101,7 +101,7 @@ describe('VFocus - Movements', function() {
     beforeEach(function() {
       leftTree = h('div', [
         h('p#first'),
-        h('p#last') 
+        h('p#last')
       ]);
 
       firstParagraph = leftTree.children[0];
@@ -135,7 +135,7 @@ describe('VFocus - Movements', function() {
         ]),
         h('p#4')
     ]);
-    
+
     firstNode = nextTree.children[0];
     secondNode = firstNode.children[0];
     thirdNode = firstNode.children[1];
@@ -159,40 +159,40 @@ describe('VFocus - Movements', function() {
    });
  });
 
+
   describe('prev()', function() {
 
-    var prevTreeFocus, prevTree, firstNode, secondNode, thirdNode, fourthNode;
+    var prevTreeFocus;
     beforeEach(function() {
-      prevTree = h(
-        'div', [
-          h('p#4', [
-            h('b#3'),
-            h('i#2')
+      var prevTree = h(
+        'div#sixth', [
+          h('p#fifth', [
+            h('gu-note#fourth', [
+              new VText('third')
+            ]),
+            new VText('second')
           ]),
-          h('p#1')
+          h('p#first', [
+            h('gu-note#start', [
+              new VText('Some noted text')
+            ]),
+            new VText('Some more text here')
+          ])
       ]);
-          
-      firstNode = prevTree.children[1];
-      fourthNode = prevTree.children[0];
-      secondNode = fourthNode.children[1];
-      thirdNode = fourthNode.children[0];
 
       prevTreeFocus = new VFocus(prevTree);
     });
 
-    it('focuses prev nodes in the right order', function() {
-      // go to the last element of the three
-      var firstPrevFocus = prevTreeFocus.next().next().next().next();
-      expect(firstPrevFocus.vNode).to.equal(firstNode);
+    it('focuses previous nodes in the right order', function() {
+      var startFocus = prevTreeFocus.find(f => f.vNode.properties && f.vNode.properties.id === 'start');
+      var steps = startFocus.takeWhile(f => f, 'prev');
 
-      var secondPrevFocus = firstPrevFocus.prev();
-      expect(secondPrevFocus.vNode).to.equal(secondNode);
-
-      var thirdPrevFocus = secondPrevFocus.prev();
-      expect(thirdPrevFocus.vNode).to.equal(thirdNode);
-
-      var fourthPrevFocus = thirdPrevFocus.prev();
-      expect(fourthPrevFocus.vNode).to.equal(fourthNode);
+      expect(steps[1].vNode.properties.id).to.equal('first');
+      expect(steps[2].vNode.text).to.equal('second');
+      expect(steps[3].vNode.text).to.equal('third');
+      expect(steps[4].vNode.properties.id).to.equal('fourth');
+      expect(steps[5].vNode.properties.id).to.equal('fifth');
+      expect(steps[6].vNode.properties.id).to.equal('sixth');
     });
   });
 


### PR DESCRIPTION
Fixes #127 

The algorithm used wasn't quite correct. In some cases (such as #127) it'd skip nodes. Amended the test for `prev()` so it tests this case.

## How to test
All unit and integration tests within the noting plugin pass (locally at least) so should be relatively safe. It'd still be worth doing a bit of regression testing to see that notes/flags/corrects works as expected.