### PR TITLE
Bug fixes

### DIFF
--- a/src/actions/noting/remove-empty-notes.js
+++ b/src/actions/noting/remove-empty-notes.js
@@ -30,11 +30,7 @@ module.exports = function removeEmptyNotes(focus, tagName = config.get('defaultT
       return;
     }
 
-    //assume we have only empty child elements
-    //if one is not change the state of the check
-    var childrenAreEmpty = noteSequence.reduce((check, childFocus)=> {
-      return !isEmpty(childFocus) ? false : true;
-    }, true);
+    var childrenAreEmpty = noteSequence.every(isEmpty);
 
     //if a note is totally empty remove it
     if (childrenAreEmpty) noteParent.remove();

--- a/src/actions/noting/toggle-note-classes.js
+++ b/src/actions/noting/toggle-note-classes.js
@@ -2,17 +2,17 @@ var _ = require('lodash');
 var toggleClass = require('../vdom/toggle-class');
 var addClass = require('../vdom/add-class');
 var removeClass = require('../vdom/remove-class');
-var collapseState = require('../../utils/collapse-state');
 var errorHandle = require('../../utils/error-handle');
+var hasClass = require('../../utils/vdom/has-class');
+var isVFocus = require('../../utils/vfocus/is-vfocus');
 
 module.exports = function toggleNoteClasses(notes, className) {
-
-  if (!notes || !className) {
-    errorHandle('Only a valid VFocus can be passed to toggleNoteClasses, you passed: %s', focus);
-  }
-
   notes = _.isArray(notes) ? notes : [notes];
   notes = _.flatten(notes);
+
+  if (notes.some(focus => !isVFocus(focus)) || !className) {
+    errorHandle('Only a valid VFocus(es) can be passed to toggleNoteClasses, you passed: %s', notes);
+  }
 
   var action;
   if (notes.length === 1) {
@@ -21,7 +21,7 @@ module.exports = function toggleNoteClasses(notes, className) {
     action = toggleClass;
   } else {
     //if we have more than one note then we want them all to share state
-    var state = collapseState.get();
+    var state = notes.every(noteSegment => hasClass(noteSegment.vNode, className));
     state ? action = removeClass : action = addClass;
   }
 

--- a/src/generate-note-controller.js
+++ b/src/generate-note-controller.js
@@ -186,6 +186,7 @@ module.exports = function(scribe){
     //toggleSelectedNotesCollapseState will collapse or expand all (or a selected) note
     toggleSelectedNotesCollapseState(tagName) {
       mutateScribe(scribe, (focus)=> toggleSelectedNoteCollapseState(focus, tagName));
+      this.clearSelection();
     }
 
     // This command is a bit special in the sense that it will operate on all

--- a/src/utils/vdom/has-class.js
+++ b/src/utils/vdom/has-class.js
@@ -1,14 +1,10 @@
-var _ = require('lodash');
 // Check if VNode has class
-// TODO: Currently not working on nodes with multiple classes (not an
-// issue at the moment).
 module.exports = function hasClass(vNode, value) {
 
   if (!vNode || !vNode.properties || !vNode.properties.className) {
     return false;
   }
 
-  var regEx = new RegExp(value);
-  return regEx.test(vNode.properties.className);
-
+  const classes = vNode.properties.className.split(' ');
+  return classes.some(cl => value === cl);
 };

--- a/test/unit/actions/noting/remove-empty-notes.spec.js
+++ b/test/unit/actions/noting/remove-empty-notes.spec.js
@@ -13,7 +13,7 @@ var flattenTree = require(path.resolve(process.cwd(), 'src/utils/vfocus/flatten-
 
 describe('removeEmptyNotes()', function() {
 
-  it('should do nothing is a tree contains no notes', function() {
+  it('should do nothing if a tree contains no notes', function() {
     var div = new VFocus(h('div'));
     removeEmptyNotes(div);
     expect(div).to.equal(div);
@@ -35,13 +35,13 @@ describe('removeEmptyNotes()', function() {
 
   });
 
-  it('should leave notes with children', function() {
+  it('should leave notes where some child is non-empty', function() {
     var tree = h('div', [
       h('gu-note'),
       h('gu-note', [
         new VText('This is some text'),
         new VText('This is some text'),
-        new VText('This is some text')
+        new VText('')
       ]),
       h('gu-note')
     ])

--- a/test/unit/actions/noting/toggle-note-classes.spec.js
+++ b/test/unit/actions/noting/toggle-note-classes.spec.js
@@ -2,9 +2,8 @@ var path = require('path');
 var chai = require('chai');
 var expect = chai.expect;
 
-var collapseState = require(path.resolve(process.cwd(), 'src/utils/collapse-state'));
-
 var h = require('virtual-hyperscript');
+var VFocus = require(path.resolve(process.cwd(), 'src/vfocus'));
 
 var toggleNoteClasses = require(path.resolve(process.cwd(), 'src/actions/noting/toggle-note-classes'));
 
@@ -12,26 +11,23 @@ describe('toggleClass()', function() {
 
   it('should toggle a class on all notes', function() {
 
-    //explicitly set the state
-    collapseState.set(false);
-
-    var notes = [
-      h('gu-note'),
-      h('gu-note'),
-      h('gu-note')
+    const noteSegments = [
+      new VFocus(h('gu-note')),
+      new VFocus(h('gu-note')),
+      new VFocus(h('gu-note'))
     ];
 
-    toggleNoteClasses(notes, 'my-class');
+    toggleNoteClasses(noteSegments, 'my-class');
 
-    notes.forEach(function(note) {
-      expect(note.properties.className).to.equal('my-class');
+    noteSegments.forEach(function(noteSegment) {
+      expect(noteSegment.vNode.properties.className).to.equal('my-class');
     });
 
-    collapseState.set(true);
-    toggleNoteClasses(notes, 'my-class');
 
-    notes.forEach(function(note) {
-      expect(note.properties.className).to.equal('');
+    toggleNoteClasses(noteSegments, 'my-class');
+
+    noteSegments.forEach(function(noteSegment) {
+      expect(noteSegment.vNode.properties.className).to.equal('');
     });
 
   });


### PR DESCRIPTION
Fixes 2 noting bugs.

## Bug 1: Can't expand note
**To replicate you can for example do:**

1. Make some text bold.
2. Create a note that starts before the bold text and ends after it.
3. Collapse it.
4. Try to expand it.

## Bug 2: Text is selected when expanding a note

**To replicate:**
Try expanding a note. Either the whole or part of the note will be highlighted.

## Bug 3: https://github.com/guardian/scribe-plugin-noting/issues/133