### PR TITLE
Remove dependency on lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,19 @@
   "version": "0.3.32",
   "main": "scribe-plugin-noting.js",
   "dependencies": {
-    "lodash": "^2.4.1",
+    "lodash.assign": "^3.2.0",
+    "lodash.difference": "^3.2.1",
+    "lodash.flatten": "^3.0.2",
+    "lodash.isobject": "^3.0.2",
+    "lodash.throttle": "^3.0.3",
+    "lodash.toarray": "^3.0.2",
     "vdom-virtualize": "git://github.com/marcelklehr/vdom-virtualize.git#38c9027e35d194502f74455be721ae49fb31621c",
     "virtual-dom": "0.0.20",
     "virtual-hyperscript": "4.4.0",
     "vtree": "0.0.20"
   },
   "devDependencies": {
+    "lodash": "^2.4.1",
     "babel": "^4.7.8",
     "babelify": "^5.0.4",
     "bower": "^1.3.12",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "vtree": "0.0.20"
   },
   "devDependencies": {
-    "lodash": "^2.4.1",
     "babel": "^4.7.8",
     "babelify": "^5.0.4",
     "bower": "^1.3.12",

--- a/src/actions/noting/create-note-from-selection.js
+++ b/src/actions/noting/create-note-from-selection.js
@@ -37,10 +37,12 @@ module.exports = function createNoteFromSelection(focus, tagName = config.get('d
   var wrappedTextNodes = toWrapAndReplace.map(focus => wrapInNote(focus.vNode, noteDataSet, tagName));
 
   // Replace the nodes in the tree with the wrapped versions.
-  _.zip(toWrapAndReplace, wrappedTextNodes).forEach(focusAndReplacementVNode => {
-    var focus = focusAndReplacementVNode[0];
-    var replacementVNode = focusAndReplacementVNode[1];
-    focus.replace(replacementVNode);
+  toWrapAndReplace
+    .map((f, i) => [toWrapAndReplace[i], wrappedTextNodes[i]]) // zip
+    .forEach(focusAndReplacementVNode => {
+      var focus = focusAndReplacementVNode[0];
+      var replacementVNode = focusAndReplacementVNode[1];
+      focus.replace(replacementVNode);
   });
 
   // If we end up with an empty note a <BR> tag would be created. We have to do

--- a/src/actions/noting/create-note-from-selection.js
+++ b/src/actions/noting/create-note-from-selection.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var VText = require('vtree/vtext');
 var config = require('../../config');
 
@@ -37,13 +36,7 @@ module.exports = function createNoteFromSelection(focus, tagName = config.get('d
   var wrappedTextNodes = toWrapAndReplace.map(focus => wrapInNote(focus.vNode, noteDataSet, tagName));
 
   // Replace the nodes in the tree with the wrapped versions.
-  toWrapAndReplace
-    .map((f, i) => [toWrapAndReplace[i], wrappedTextNodes[i]]) // zip
-    .forEach(focusAndReplacementVNode => {
-      var focus = focusAndReplacementVNode[0];
-      var replacementVNode = focusAndReplacementVNode[1];
-      focus.replace(replacementVNode);
-  });
+  toWrapAndReplace.forEach((focus, i) => focus.replace(wrappedTextNodes[i]));
 
   // If we end up with an empty note a <BR> tag would be created. We have to do
   // this before we remove the markers.

--- a/src/actions/noting/merge-if-necessary.js
+++ b/src/actions/noting/merge-if-necessary.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var isVFocus = require('../../utils/vfocus/is-vfocus');
 var errorHandle = require('../../utils/error-handle');
 var findAllNotes = require('../../utils/noting/find-all-notes');
@@ -42,12 +41,11 @@ module.exports = function mergeIfNecessary(focus, tagName = config.get('defaultT
   .filter(note => {
 
     //find any inconsistent time stamps
-    var inconsistentTimeStamps = _(note)
-    .map(segment => !!segment.vNode.properties.dataset.noteEditedBy)
-    .uniq()
-    .value();
+    var inconsistentTimeStamps = new Set(
+      note.map(segment => !!segment.vNode.properties.dataset.noteEditedBy)
+    );
 
-    if(inconsistentTimeStamps.length > 1){
+    if (inconsistentTimeStamps.size > 1) {
       return true;
     }
 

--- a/src/actions/noting/remove-character-from-adjacent-note.js
+++ b/src/actions/noting/remove-character-from-adjacent-note.js
@@ -1,5 +1,5 @@
 var VFocus = require('../../vfocus');
-var _ = require('lodash');
+var flatten = require('lodash.flatten');
 var isVFocus = require('../../utils/vfocus/is-vfocus');
 var errorHandle = require('../../utils/error-handle');
 var config = require('../../config');
@@ -58,7 +58,7 @@ module.exports = function removeCharacterFromAdjacentNote(focus, direction = 'ne
     var textNodes = note.map((noteSegment)=>{
       return noteSegment.children().filter((node)=> isVText(new VFocus(node)));
     });
-    textNodes = _.flatten(textNodes);
+    textNodes = flatten(textNodes);
     textNode = textNodes[textNodes.length -1].text === '\u200B'
       ? textNodes[textNodes.length - 2]
       : textNodes[textNodes.length - 1];

--- a/src/actions/noting/remove-empty-notes.js
+++ b/src/actions/noting/remove-empty-notes.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+var flatten = require('lodash.flatten');
 var isVFocus = require('../../utils/vfocus/is-vfocus');
 var isVText = require('../../utils/vfocus/is-vtext');
 var isEmpty = require('../../utils/vfocus/is-empty');
@@ -16,7 +16,7 @@ module.exports = function removeEmptyNotes(focus, tagName = config.get('defaultT
   }
 
   //return all notes from the given tree
-  var allNoteSegments = _.flatten(findAllNotes(focus, tagName));
+  var allNoteSegments = flatten(findAllNotes(focus, tagName));
 
   var noteSequences = allNoteSegments.map(flattenTree);
 

--- a/src/actions/noting/remove-part-of-note.js
+++ b/src/actions/noting/remove-part-of-note.js
@@ -67,7 +67,7 @@ module.exports = function removePartofNote(focus, tagName = config.get('defaultT
   var wrappedTextNodes = toWrapAndReplace.map(nodeFocus => wrapInNote(nodeFocus, noteData, tagName));
 
   // Replace the nodes in the tree with the wrapped versions.
-  _.zip(focusesToNote, wrappedTextNodes).forEach(node => node[0].replace(node[1]));
+  focusesToNote.forEach((focus, i) => focus.replace(wrappedTextNodes[i]));
 
   // Unwrap previously existing note.
   entireNote.forEach((node)=> unWrapNote(node, tagName));

--- a/src/actions/noting/remove-part-of-note.js
+++ b/src/actions/noting/remove-part-of-note.js
@@ -1,4 +1,6 @@
-var _ = require('lodash');
+var difference = require('lodash.difference');
+var flatten = require('lodash.flatten');
+
 var VText = require('vtree/vtext');
 var config = require('../../config');
 
@@ -50,12 +52,11 @@ module.exports = function removePartofNote(focus, tagName = config.get('defaultT
   var focusesToUnnote = findTextBetweenScribeMarkers(focus);
   var entireNote = findEntireNote(focusesToUnnote[0], tagName);
 
-  var entireNoteTextNodeFocuses = _(entireNote).map(flattenTree)
-  .flatten().value().filter(isVText);
+  var entireNoteTextNodeFocuses = flatten(entireNote.map(flattenTree)).filter(isVText);
 
   var entireNoteTextNodes = entireNoteTextNodeFocuses.map(nodeFocus => nodeFocus.vNode);
   var textNodesToUnote = focusesToUnnote.map(nodeFocus => nodeFocus.vNode);
-  var toWrapAndReplace = _.difference(entireNoteTextNodes, textNodesToUnote);
+  var toWrapAndReplace = difference(entireNoteTextNodes, textNodesToUnote);
 
   var focusesToNote = entireNoteTextNodeFocuses.filter(nodeFocus => {
     return (textNodesToUnote.indexOf(nodeFocus.vNode) === -1)

--- a/src/actions/noting/reset-note-segment-classes.js
+++ b/src/actions/noting/reset-note-segment-classes.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var addClass = require('../../actions/vdom/add-class');
 var removeClass = require('../../actions/vdom/remove-class');
 var isVFocus = require('../../utils/vfocus/is-vfocus');
@@ -16,7 +15,7 @@ module.exports = function updateStartAndEndClasses(noteSegments, tagName = confi
     return;
   }
 
-  noteSegments = _.isArray(noteSegments) ? noteSegments : [noteSegments];
+  noteSegments = Array.isArray(noteSegments) ? noteSegments : [noteSegments];
 
   var uuid = generateUUID();
 

--- a/src/actions/noting/toggle-note-classes.js
+++ b/src/actions/noting/toggle-note-classes.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+var flatten = require('lodash.flatten');
 var toggleClass = require('../vdom/toggle-class');
 var addClass = require('../vdom/add-class');
 var removeClass = require('../vdom/remove-class');
@@ -8,7 +8,7 @@ var isVFocus = require('../../utils/vfocus/is-vfocus');
 
 module.exports = function toggleNoteClasses(notes, className) {
   notes = Array.isArray(notes) ? notes : [notes];
-  notes = _.flatten(notes);
+  notes = flatten(notes);
 
   if (notes.some(focus => !isVFocus(focus)) || !className) {
     errorHandle('Only a valid VFocus(es) can be passed to toggleNoteClasses, you passed: %s', notes);

--- a/src/actions/noting/toggle-note-classes.js
+++ b/src/actions/noting/toggle-note-classes.js
@@ -7,7 +7,7 @@ var hasClass = require('../../utils/vdom/has-class');
 var isVFocus = require('../../utils/vfocus/is-vfocus');
 
 module.exports = function toggleNoteClasses(notes, className) {
-  notes = _.isArray(notes) ? notes : [notes];
+  notes = Array.isArray(notes) ? notes : [notes];
   notes = _.flatten(notes);
 
   if (notes.some(focus => !isVFocus(focus)) || !className) {

--- a/src/actions/noting/unwrap-note.js
+++ b/src/actions/noting/unwrap-note.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+var flatten = require('lodash.flatten');
 var isVFocus = require('../../utils/vfocus/is-vfocus');
 var isNoteSegment = require('../../utils/noting/is-note-segment');
 var errorHandle = require('../../utils/error-handle');
@@ -21,7 +21,7 @@ module.exports = function unWrapNote(focus, tagName = config.get('defaultTagName
   //remove note and add children
   tree.splice(tree.indexOf(note), 1, note.children);
 
-  focus.parent.vNode.children = _.flatten(tree);
+  focus.parent.vNode.children = flatten(tree);
 
   // We want the note contents to now have their grandparent as parent.
   // The safest way we can ensure this is by changing the VFocus object

--- a/src/actions/noting/wrap-in-note.js
+++ b/src/actions/noting/wrap-in-note.js
@@ -9,7 +9,7 @@ var config = require('../../config');
 // toWrap can be a vNode, DOM node or a string. One or an array with several.
 module.exports = function wrapInNote(focus, data, tagName = config.get('defaultTagName')){
 
-  var notes = _.isArray(focus) ? focus : [focus];
+  var notes = Array.isArray(focus) ? focus : [focus];
 
   //data MUST be cloned as this can lead to multiple notes with the same note ID see:
   // https://github.com/guardian/scribe-plugin-noting/issues/45

--- a/src/actions/noting/wrap-in-note.js
+++ b/src/actions/noting/wrap-in-note.js
@@ -1,9 +1,9 @@
+var assign = require('lodash.assign');
+
 var config = require('../../config');
-var _ = require('lodash');
 var h = require('virtual-hyperscript');
 
 var getUKDate = require('../../utils/get-uk-date');
-var config = require('../../config');
 
 // Wrap in a note.
 // toWrap can be a vNode, DOM node or a string. One or an array with several.
@@ -13,7 +13,7 @@ module.exports = function wrapInNote(focus, data, tagName = config.get('defaultT
 
   //data MUST be cloned as this can lead to multiple notes with the same note ID see:
   // https://github.com/guardian/scribe-plugin-noting/issues/45
-  data = _.extend({}, (data || {}));
+  data = assign({}, (data || {}));
 
   tagName = tagName + '.' + config.get('className');
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+var assign = require('lodash.assign');
 
 //defaults
 var config = {
@@ -38,7 +38,7 @@ module.exports = {
 
     //if you pass an object we override ALL THE THINGS
     if(_.isObject(key)){
-      config = _.extend({}, config, key);
+      config = assign({}, config, key);
     }
 
     //else set a specific key

--- a/src/generate-note-controller.js
+++ b/src/generate-note-controller.js
@@ -33,7 +33,7 @@ var mutateScribe = notingVDom.mutateScribe;
 emitter.on('command:toggle:all-notes', tag => {
   var state = !!noteCollapseState.get();
   var scribeInstances = document.querySelectorAll(config.get('scribeInstanceSelector'));
-  scribeInstances = _.toArray(scribeInstances);
+  scribeInstances = Array.toArray(scribeInstances);
   scribeInstances.forEach(instance => {
     mutate(instance, focus => toggleAllNoteCollapseState(focus));
   });
@@ -194,7 +194,7 @@ module.exports = function(scribe){
     toggleAllNotesCollapseState() {
       var state = !!noteCollapseState.get();
       var scribeInstances = document.querySelectorAll(config.get('scribeInstanceSelector'));
-      scribeInstances = _.toArray(scribeInstances);
+      scribeInstances = Array.toArray(scribeInstances);
       scribeInstances.forEach(instance => {
         mutate(instance, focus => toggleAllNoteCollapseState(focus));
       });

--- a/src/generate-note-controller.js
+++ b/src/generate-note-controller.js
@@ -1,4 +1,6 @@
-var _ = require('lodash');
+var toArray = require('lodash.toarray');
+var isObject = require('lodash.isobject');
+var throttle = require('lodash.throttle');
 
 var config = require('./config');
 var emitter = require('./utils/emitter');
@@ -33,7 +35,7 @@ var mutateScribe = notingVDom.mutateScribe;
 emitter.on('command:toggle:all-notes', tag => {
   var state = !!noteCollapseState.get();
   var scribeInstances = document.querySelectorAll(config.get('scribeInstanceSelector'));
-  scribeInstances = Array.toArray(scribeInstances);
+  scribeInstances = toArray(scribeInstances);
   scribeInstances.forEach(instance => {
     mutate(instance, focus => toggleAllNoteCollapseState(focus));
   });
@@ -110,10 +112,10 @@ module.exports = function(scribe){
 
         selector.keyCodes.forEach(keyCode => {
           //if we get just a number we check the keyCode
-          if (!_.isObject(keyCode) && e.keyCode === keyCode){
+          if (!isObject(keyCode) && e.keyCode === keyCode){
             e.preventDefault();
             this.note(tagName);
-          } else if(_.isObject(keyCode)){
+          } else if(isObject(keyCode)){
             //in the dynamic case we need to check for BOTH the modifier key AND keycode
             var modifier = Object.keys(keyCode)[0];
             if(e[modifier] && e.keyCode === keyCode[modifier]){
@@ -194,7 +196,7 @@ module.exports = function(scribe){
     toggleAllNotesCollapseState() {
       var state = !!noteCollapseState.get();
       var scribeInstances = document.querySelectorAll(config.get('scribeInstanceSelector'));
-      scribeInstances = Array.toArray(scribeInstances);
+      scribeInstances = toArray(scribeInstances);
       scribeInstances.forEach(instance => {
         mutate(instance, focus => toggleAllNoteCollapseState(focus));
       });
@@ -230,7 +232,7 @@ module.exports = function(scribe){
         }
 
         //check that the selection is within a note
-        var selector = _.find(config.get('selectors'), (selector) => {
+        var selector = config.get('selectors').find(selector => {
           // isSelectionWithinNote rather than isSelectionEntirelyWithinNote
           // since we want to allow all clicks within a note, even if it
           // selects the note and some text to the left or right of the note.
@@ -306,7 +308,7 @@ module.exports = function(scribe){
 
     //validateNotes makes sure all note--start note--end and data attributes are in place
     validateNotes() {
-      _.throttle(()=> {
+      throttle(()=> {
         this.ensureNoteIntegrity();
       }, 1000)();
     }

--- a/src/noting-vdom.js
+++ b/src/noting-vdom.js
@@ -4,8 +4,6 @@
 
 var TAG = 'gu-note';
 
-var _ = require('lodash');
-
 var diff = require('virtual-dom/diff');
 var patch = require('virtual-dom/patch');
 

--- a/src/utils/noting/find-all-notes.js
+++ b/src/utils/noting/find-all-notes.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var isVFocus = require('../vfocus/is-vfocus');
 var isNoteSegment = require('./is-note-segment');
 var findEntireNote = require('./find-entire-note');
@@ -20,7 +19,8 @@ module.exports = function findAllNotes(focus, tagName = config.get('defaultTagNa
       if (uniqueNotes.length === 0) return uniqueNotes.concat([note]);
 
       // Subsequent iterations: Add the note if it hasn't already been added.
-      return _.last(uniqueNotes)[0].vNode === note[0].vNode ? uniqueNotes : uniqueNotes.concat([note]);
+      var lastUniqueNote = uniqueNotes[uniqueNotes.length - 1];
+      return lastUniqueNote[0].vNode === note[0].vNode ? uniqueNotes : uniqueNotes.concat([note]);
     }, []);
 
 };

--- a/src/utils/noting/find-first-note-segment.js
+++ b/src/utils/noting/find-first-note-segment.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var isVFocus = require('../vfocus/is-vfocus');
 var stillWithinNote = require('./still-within-note');
 var isNoteSegment = require('./is-note-segment');
@@ -11,9 +10,7 @@ module.exports = function findFirstNoteSegment(focus, tagName = config.get('defa
     errorHandle('Only a valid VFocus can be passed to findFirstNoteSegment, you passed: %s', focus);
   }
 
-  return _.last(
-    focus.takeWhile((node)=> stillWithinNote(node, tagName), 'prev').filter((node)=> isNoteSegment(node, tagName))
-  );
-
-
+  return focus.takeWhile((node) => stillWithinNote(node, tagName), 'prev')
+              .filter((node) => isNoteSegment(node, tagName))
+              .pop();
 };

--- a/src/utils/noting/find-note-by-id.js
+++ b/src/utils/noting/find-note-by-id.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+var flatten = require('lodash.flatten');
 var isVFocus = require('../vfocus/is-vfocus');
 var hasNoteId = require('./has-note-id');
 var findAllNotes = require('./find-all-notes');
@@ -19,7 +19,7 @@ module.exports = function findNoteById(focus, noteId, tagName = config.get('defa
   }
 
 
-  var allNoteSegments = _.flatten(findAllNotes(focus, tagName));
+  var allNoteSegments = flatten(findAllNotes(focus, tagName));
   return allNoteSegments.filter((segment)=> hasNoteId(segment.vNode, noteId));
 
 };

--- a/src/utils/noting/is-caret-next-to-note.js
+++ b/src/utils/noting/is-caret-next-to-note.js
@@ -3,7 +3,6 @@ var errorHandle = require('../error-handle');
 var config = require('../../config');
 var findScribeMarkers = require('./find-scribe-markers');
 var findPreviousNoteSegment = require('./find-previous-note-segment');
-var isNoteSegment = require('../noting/is-note-segment');
 var isScribeMarker = require('./is-scribe-marker.js');
 
 module.exports = function isCaretNextToNote(focus, direction = 'next', tagName = config.get('defaultTagName')){

--- a/src/utils/noting/is-note-segment.js
+++ b/src/utils/noting/is-note-segment.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var isVFocus = require('../vfocus/is-vfocus');
 var isTag = require('../vdom/is-tag');
 var errorHandle = require('../error-handle');
@@ -6,19 +5,18 @@ var config = require('../../config');
 
 // function isNote
 // identifies whether a given vfocus is a note
-module.exports = function isNote(vfocus, tagName = config.get('defaultTagName')) {
+module.exports = function isNoteSegment(focus, tagName) {
 
-  if (!isVFocus(vfocus)) {
+  if (!isVFocus(focus)) {
     errorHandle('Only a valid VFocus element can be passed to isNote, you passed: %s', focus);
   }
 
-
   //if this function is placed within a iterator (takeWhile for example)
   //the index will be passed as second argument
-  //as such we need to correct this or we won't get a correct result
-  if(!_.isString(tagName)){
-    tagName = config.get('defaultTagName');
+  //as such we it's a good idea to check this.
+  if(! typeof tagName === 'string') {
+    errorHandle('tagName has to be passed to isNote as the second parameter, you passed: %s', tagName);
   }
 
-  return isTag(vfocus.vNode, tagName);
+  return isTag(focus.vNode, tagName);
 };

--- a/src/utils/noting/is-selection-entirely-within-note.js
+++ b/src/utils/noting/is-selection-entirely-within-note.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var isVFocus = require('../vfocus/is-vfocus');
 
 var findParentNoteSegment = require('./find-parent-note-segment');
@@ -16,7 +15,7 @@ module.exports = function isSelectionEntirelyWithinNote(markers, tagName = confi
   }
 
   //if we get passed the wrong argument
-  if (!_.isArray(markers)) {
+  if (!Array.isArray(markers)) {
     errorHandle('Only an array of markers or valid VFocus can be passed to isSelectionBetweenMarkers, you passed: %s', focus);
   }
 

--- a/src/utils/noting/is-selection-within-note.js
+++ b/src/utils/noting/is-selection-within-note.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var isVFocus = require('../vfocus/is-vfocus');
 
 var findParentNoteSegment = require('./find-parent-note-segment');
@@ -16,7 +15,7 @@ module.exports = function isSelectionWithinNote(markers, tagName = config.get('d
   }
 
   //if we get passed the wrong argument
-  if (!_.isArray(markers)) {
+  if (!Array.isArray(markers)) {
     errorHandle('Only an array of markers or valid VFocus can be passed to isSelectionBetweenMarkers, you passed: %s', focus);
   }
 

--- a/src/utils/vdom/is-empty.js
+++ b/src/utils/vdom/is-empty.js
@@ -7,8 +7,6 @@
 // hasn't asked for that. We compensate for this by moving any deleted
 // space to the previous note segment.
 
-
-var _ = require('lodash');
 var isVText = require('vtree/is-vtext');
 
 module.exports = function(node) {

--- a/src/utils/vfocus/find-text-nodes.js
+++ b/src/utils/vfocus/find-text-nodes.js
@@ -1,11 +1,10 @@
-var _ = require('lodash');
 var isVFocus = require('../vfocus/is-vfocus');
 var isVText = require('../vfocus/is-vtext');
 var errorHandle = require('../error-handle');
 
 module.exports = function findTextNodes(focuses) {
 
-  focuses = _.isArray(focuses) ? focuses : [focuses];
+  focuses = Array.isArray(focuses) ? focuses : [focuses];
 
   focuses.forEach(function(focus) {
     if (!isVFocus(focus)) {

--- a/test/integration/merge-note.spec.js
+++ b/test/integration/merge-note.spec.js
@@ -1,7 +1,6 @@
 var chai = require('chai');
 var webdriver = require('selenium-webdriver');
 var helpers = require('scribe-test-harness/helpers');
-var _ = require('lodash');
 
 var expect = chai.expect;
 
@@ -61,7 +60,12 @@ describe('Merging Scribe Notes', function() {
           it('wraps the text in a note', function() {
             scribeNode.sendKeys(webdriver.Key.DELETE);
               scribeNode.getInnerHTML().then(function(innerHTML) {
-                var hasSameIds = _.uniq(innerHTML.match(/data-note-id="(.*?)"/g)).length === 1;
+                var noteIds = innerHTML.match(/data-note-id="(.*?)"/g);
+                var uniqueIds = noteIds.filter(function(noteId, i) {
+                    return noteIds.indexOf(noteId) === i;
+                  });
+
+                var hasSameIds = uniqueIds.length === 1;
                 expect(hasSameIds).to.be.true;
               });
           });

--- a/test/unit/actions/noting/create-note-at-caret.spec.js
+++ b/test/unit/actions/noting/create-note-at-caret.spec.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 

--- a/test/unit/actions/noting/create-note-from-selection.spec.js
+++ b/test/unit/actions/noting/create-note-from-selection.spec.js
@@ -1,6 +1,5 @@
 var util = require('util');
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 

--- a/test/unit/actions/noting/remove-empty-notes.spec.js
+++ b/test/unit/actions/noting/remove-empty-notes.spec.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 

--- a/test/unit/actions/noting/remove-note.spec.js
+++ b/test/unit/actions/noting/remove-note.spec.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 

--- a/test/unit/actions/noting/remove-part-of-note.spec.js
+++ b/test/unit/actions/noting/remove-part-of-note.spec.js
@@ -1,7 +1,6 @@
 
 var util = require('util');
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 

--- a/test/unit/actions/noting/remove-scribe-markers.js
+++ b/test/unit/actions/noting/remove-scribe-markers.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 
@@ -33,8 +32,8 @@ describe('removeScribeMarkers()', function() {
     removeScribemarkers(tree);
     tree = flattenTree(tree);
 
-    expect(_.contains(tree, marker1)).to.be.false;
-    expect(_.contains(tree, marker2)).to.be.false;
+    expect(tree.indexOf, marker1)).to.be(-1);
+    expect(tree.indexOf, marker2)).to.not.be(-1);
 
   });
 

--- a/test/unit/actions/noting/reset-note-barriers.spec.js
+++ b/test/unit/actions/noting/reset-note-barriers.spec.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 

--- a/test/unit/actions/noting/reset-note-segment-classes.spec.js
+++ b/test/unit/actions/noting/reset-note-segment-classes.spec.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 

--- a/test/unit/actions/noting/select-note.spec.js
+++ b/test/unit/actions/noting/select-note.spec.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 

--- a/test/unit/actions/noting/unwrap-note.spec.js
+++ b/test/unit/actions/noting/unwrap-note.spec.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 

--- a/test/unit/actions/noting/wrap-in-note.spec.js
+++ b/test/unit/actions/noting/wrap-in-note.spec.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 

--- a/test/unit/utils/noting/find-all-notes.spec.js
+++ b/test/unit/utils/noting/find-all-notes.spec.js
@@ -1,7 +1,8 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
+
+var flatten = require('lodash.flatten');
 
 var h = require('virtual-hyperscript');
 var VText = require('vtree/vtext');
@@ -36,7 +37,7 @@ describe('findAllNotes()', function() {
     ]);
     tree = new VFocus(tree);
 
-    var result = _.flatten(findAllNotes(tree));
+    var result = flatten(findAllNotes(tree));
     expect(result.length).to.equal(2);
   });
 

--- a/test/unit/utils/noting/is-note-segment.spec.js
+++ b/test/unit/utils/noting/is-note-segment.spec.js
@@ -18,11 +18,11 @@ beforeEach(function(){
 describe('isNoteSegment()', function(){
 
   it('should correctly identify a note element', function(){
-    expect(isNoteSegment(noteFocus)).to.be.true;
+    expect(isNoteSegment(noteFocus, 'gu-note')).to.be.true;
   });
 
   it('should correctly identify an element which is not a note', function(){
-    expect(isNoteSegment(divFocus)).to.be.false;
+    expect(isNoteSegment(divFocus, 'gu-note')).to.be.false;
   });
 
 });

--- a/test/unit/vfocus/checks.spec.js
+++ b/test/unit/vfocus/checks.spec.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 

--- a/test/unit/vfocus/iterations.spec.js
+++ b/test/unit/vfocus/iterations.spec.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 
@@ -21,7 +20,7 @@ describe('VFocus - Iterations', function() {
           ]),
           h('p#4')
       ]);
-    
+
       forEachTreeFocus = new VFocus(forEachTree);
     });
 
@@ -134,7 +133,7 @@ describe('VFocus - Iterations', function() {
           h('p')
       ]);
 
-      rootVFocus = new VFocus(findTree);      
+      rootVFocus = new VFocus(findTree);
     });
 
     it('finds the node with the expected id', function(){

--- a/test/unit/vfocus/movements.spec.js
+++ b/test/unit/vfocus/movements.spec.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 

--- a/test/unit/vfocus/mutating.spec.js
+++ b/test/unit/vfocus/mutating.spec.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var _ = require('lodash');
 var chai = require('chai');
 var expect = chai.expect;
 
@@ -13,7 +12,7 @@ describe('VFocus - Mutations', function() {
   describe('replace()', function() {
 
     var replaceTree, replaceTreeFocus, replaceRootNode, replaceNode;
-    
+
     beforeEach(function() {
       replaceTree = h('div', [
         h('p#1')
@@ -30,7 +29,7 @@ describe('VFocus - Mutations', function() {
 
     it('replaces and focuses the root node', function() {
       replaceTreeFocus.replace(replaceRootNode);
-    
+
       expect(replaceTreeFocus.vNode).to.equal(replaceRootNode);
     });
 


### PR DESCRIPTION
Removes the dependency on lodash, preferring ES6 functions where possible, occasionally requiring packaged versions of individual lodash functions where that makes sense.

**Note:** Some ES6 features aren't available via Babel unless you include `babel/polyfill`. Getting this to work with the current build/testing setup is problematic. I don't think it's worth making it work at this point. This is why we still use lodash's `toArray` for example.