### PR TITLE
Array.prototype.find is part of babel/polyfill. Use lodash for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "lodash.assign": "^3.2.0",
     "lodash.difference": "^3.2.1",
+    "lodash.find": "^3.2.1",
     "lodash.flatten": "^3.0.2",
     "lodash.isobject": "^3.0.2",
     "lodash.throttle": "^3.0.3",

--- a/src/generate-note-controller.js
+++ b/src/generate-note-controller.js
@@ -1,6 +1,7 @@
 var toArray = require('lodash.toarray');
 var isObject = require('lodash.isobject');
 var throttle = require('lodash.throttle');
+var find = require('lodash.find');
 
 var config = require('./config');
 var emitter = require('./utils/emitter');
@@ -232,12 +233,12 @@ module.exports = function(scribe){
         }
 
         //check that the selection is within a note
-        var selector = config.get('selectors').find(selector => {
+        var selector = find(config.get('selectors'), (selector => {
           // isSelectionWithinNote rather than isSelectionEntirelyWithinNote
           // since we want to allow all clicks within a note, even if it
           // selects the note and some text to the left or right of the note.
           return isSelectionWithinNote(markers, selector.tagName);
-        });
+        }));
 
         //if the selection is within a note select that note
         if (selector) {


### PR DESCRIPTION
In https://github.com/guardian/scribe-plugin-noting/pull/137 we made use of `Array.prototype.find`. Turns out this is part of `babel/polyfill` which is troublesome to include in this project at the moment.

I've replaced it with the lodash modern version for now.

## How to test
1. Create a note.
2. Hit `CMD+SHIFT+A` which should select the whole note.