### PR TITLE
Fix for #144 Notes incorrectly concatenated

### DIFF
--- a/src/actions/noting/create-note-from-selection.js
+++ b/src/actions/noting/create-note-from-selection.js
@@ -22,7 +22,8 @@ var hasClass = require('../../utils/vdom/has-class');
 
 // treeFocus: tree focus of tree containing two scribe markers
 // Note that we will mutate the tree.
-module.exports = function createNoteFromSelection(focus, tagName = config.get('defaultTagName')) {
+module.exports = function createNoteFromSelection(focus, tagName = config.get('defaultTagName'), isAtLeastPartiallyWithinAnotherNote = false) {
+  var isStandaloneNote = !isAtLeastPartiallyWithinAnotherNote
 
   if (!isVFocus(focus)) {
     errorHandle('Only a valid VFocus element can be passed to createNoteFromSelection, you passed: %s', focus);
@@ -43,8 +44,16 @@ module.exports = function createNoteFromSelection(focus, tagName = config.get('d
   removeErroneousBrTags(focus, tagName);
 
   // Update note properties (merges if necessary).
-  var lastNoteSegment = findLastNoteSegment(toWrapAndReplace[0], tagName);
-  var noteSegments = findEntireNote(lastNoteSegment, tagName);
+  var lastNoteSegment = findLastNoteSegment(toWrapAndReplace[0], tagName, isStandaloneNote);
+
+  // Note segments are the ones selected by the user, except if the selection overlaps
+  // with an existing note. NB if the selection was completely inside another note,
+  // removeNote or removePartOfNote would be called.
+  var noteSegments = toWrapAndReplace
+  if (!isStandaloneNote) {
+    noteSegments = findEntireNote(lastNoteSegment, tagName, isStandaloneNote);
+  }
+
   resetNoteSegmentClasses(noteSegments, tagName);
 
   // We need to clear the cache, and this has to be done before we place

--- a/src/generate-note-controller.js
+++ b/src/generate-note-controller.js
@@ -286,6 +286,7 @@ module.exports = function(scribe){
         */
 
         var isWithinNote = isSelectionEntirelyWithinNote(markers, tagName);
+        var isPartiallyWithinNote = isSelectionWithinNote(markers, tagName)
 
         //If the caret is within a note and nothing is selected
         if (selectionIsCollapsed && isWithinNote){
@@ -301,7 +302,7 @@ module.exports = function(scribe){
         }
         //if we have a selection outside of a note
         else {
-          createNoteFromSelection(focus, tagName);
+          createNoteFromSelection(focus, tagName, isPartiallyWithinNote);
         }
 
       });

--- a/src/utils/noting/find-entire-note.js
+++ b/src/utils/noting/find-entire-note.js
@@ -19,7 +19,7 @@ var config = require('../../config');
 // note rather than the second.
 //
 
-module.exports = function findEntireNote(focus, tagName = config.get('defaultTagName')) {
+module.exports = function findEntireNote(focus, tagName = config.get('defaultTagName'), isStandaloneNote = false) {
 
   if (!isVFocus(focus)) {
     errorHandle('Only a valid VFocus can be passed to findEntireNote, you passed: %s', focus);
@@ -32,7 +32,7 @@ module.exports = function findEntireNote(focus, tagName = config.get('defaultTag
   }
 
   return firstNoteSegment
-    .takeWhile((node)=>stillWithinNote(node, tagName))
+    .takeWhile((node)=>stillWithinNote(node, tagName, isStandaloneNote))
     .filter((node)=>isNoteSegment(node, tagName));
 
 };

--- a/src/utils/noting/find-last-note-segment.js
+++ b/src/utils/noting/find-last-note-segment.js
@@ -1,18 +1,18 @@
 var isVFocus = require('../vfocus/is-vfocus');
 var stillWithinNote = require('./still-within-note');
 var isNoteSegment = require('./is-note-segment');
+var isEmpty = require('../vfocus/is-empty');
 var errorHandle = require('../error-handle');
 var config = require('../../config');
 
-module.exports = function findLastNoteSegment(focus, tagName = config.get('defaultTagName')) {
+module.exports = function findLastNoteSegment(focus, tagName = config.get('defaultTagName'), isStandaloneNote = false) {
 
   if (!isVFocus(focus)) {
     errorHandle('only a valid VFocus can be passed to findFirstNoteSegment, you passed: %s', focus);
   }
 
   return focus
-    .takeWhile((node)=> stillWithinNote(node, tagName))
+    .takeWhile((node)=> stillWithinNote(node, tagName, isStandaloneNote))
     .filter((node)=> isNoteSegment(node, tagName))
     .splice(-1)[0];
-
 };

--- a/src/utils/noting/find-last-note-segment.js
+++ b/src/utils/noting/find-last-note-segment.js
@@ -1,7 +1,6 @@
 var isVFocus = require('../vfocus/is-vfocus');
 var stillWithinNote = require('./still-within-note');
 var isNoteSegment = require('./is-note-segment');
-var isEmpty = require('../vfocus/is-empty');
 var errorHandle = require('../error-handle');
 var config = require('../../config');
 

--- a/src/utils/noting/still-within-note.js
+++ b/src/utils/noting/still-within-note.js
@@ -1,16 +1,21 @@
 var isVFocus = require('../vfocus/is-vfocus');
 var isVText = require('../vfocus/is-vtext');
 var isEmpty = require('../vfocus/is-empty');
+var isScribeMarker = require('./is-scribe-marker');
 var findParentNoteSegment = require('../noting/find-parent-note-segment');
 var errorHandle = require('../error-handle');
 var config = require('../../config');
 
-module.exports = function isWithinNote(focus, tagName = config.get('defaultTagName')) {
+module.exports = function isWithinNote(focus, tagName = config.get('defaultTagName'), isStandaloneNote = false) {
 
   if (!isVFocus(focus)) {
     errorHandle('Only a valid VFocus can be passed to isWithinNote, you passed: %s', focus);
   }
 
+  // We consider selection marker as the end of note when the note is not overlaping other note(s)
+  if (isStandaloneNote && isScribeMarker(focus)) {
+    return false
+  }
 
   return !isVText(focus) || isEmpty(focus) || !!findParentNoteSegment(focus, tagName);
 };


### PR DESCRIPTION
The notion of standalone note had to be introduced to be able to handle all use cases (noting on the left or right or inside other notes). With this hint `isWithinNote` and `createNoteFromSelection` work much more reliably.

Demo:

![scribe-plugin-noting-144-fix](https://cloud.githubusercontent.com/assets/2061333/12328512/902cf870-bad3-11e5-8222-6b52aeb37686.gif)
