### PR TITLE
Text highlight behaviour is normal when going over note barrier

### DIFF
--- a/src/skins/gu-note-hitzone.less
+++ b/src/skins/gu-note-hitzone.less
@@ -1,0 +1,23 @@
+/**
+ * Hitzone pseudo-elements used for hitzones at start and end of notes for
+ * toggling note collapse.
+ */
+.note-hitzone() {
+  content: '|';
+  position: relative;
+  width: 8px;
+  height: 100%;
+  cursor: pointer;
+  pointer-events: all;
+  opacity: 0;
+}
+
+.note--start::before {
+  .note-hitzone;
+  margin: 0 0 0 -3px;
+}
+
+.note--end::after {
+  .note-hitzone;
+  margin: 0 -5px 0 2px;
+}

--- a/src/skins/gu-note.less
+++ b/src/skins/gu-note.less
@@ -1,4 +1,5 @@
 @import 'vars.less';
+@import 'gu-note-hitzone.less';
 @import 'mixins/dotted-border.less';
 @import 'mixins/note/note-chevron-left.less';
 @import 'mixins/note/note-chevron-right.less';

--- a/src/skins/index.less
+++ b/src/skins/index.less
@@ -3,28 +3,6 @@
 @import 'gu-flag.less';
 @import 'gu-correct.less';
 
-/**
- * Hitzone pseudo-elements used for hitzones at start and end of notes for
- * toggling note collapse.
- */
-.note-hitzone() {
-  content: ' ';
-  position: absolute;
-  width: 8px;
-  height: 100%;
-  cursor: pointer;
-  pointer-events: all;
-}
-
-.note--start::before {
-  .note-hitzone;
-  margin-left: -5px;
-}
-
-.note--end::after {
-  .note-hitzone;
-}
-
 .note-barrier {
   /* Keeps note barriers inline. */
   display: inline-block;


### PR DESCRIPTION
Fix for #142 

Tested & confirmed in Firefox 40, Safari 9.0.2 and Chrome 47.0.2526.73.

![142-selection-ok](https://cloud.githubusercontent.com/assets/2061333/12444126/cbd04532-bf54-11e5-89dc-ec774ef6ba8b.gif)

NB in Safari the boundaries do not show the pointer cursor (hand icon) on hover but it's not a regression.