### PR TITLE
Deleting note with delete key does not reset cursor to another note

### DIFF
--- a/src/generate-note-controller.js
+++ b/src/generate-note-controller.js
@@ -319,11 +319,15 @@ module.exports = function(scribe){
       mutateScribe(scribe, (focus)=> {
         //strip the document of ALL zero width spaces
         stripZeroWidthSpaces(focus);
+      });
+
+      mutateScribe(scribe, (focus)=> {
         config.get('selectors').forEach((selector)=>{
           //run through EACH kind of note and re-add the zero width spaces
           ensureNoteIntegrity(focus, selector.tagName);
         });
       });
+
     }
 
   }


### PR DESCRIPTION
This is a possible solution for #141. Running `stripZeroWidthSpaces` and `ensureNoteIntegrity` in separate `mutateScribe` calls stops this particular issue from happening.

Fixes #141