### PR TITLE
Correct contrast for double notes

### DIFF
--- a/src/skins/gu-note-hitzone.less
+++ b/src/skins/gu-note-hitzone.less
@@ -21,3 +21,8 @@
   .note-hitzone;
   margin: 0 -5px 0 2px;
 }
+
+gu-correct.note--start::before,
+gu-flag.note--start::before {
+  opacity: 1;
+}

--- a/src/skins/vars.less
+++ b/src/skins/vars.less
@@ -1,5 +1,5 @@
 /* original note background without opacity in hex: #e6f2f7; */
-@note-background-color: rgba(230, 242, 247, 0.7);
+@note-background-color: rgba(230, 242, 247, 0.3);
 @note-border-color: rgba(41, 131, 182, 1);
 @note-text-color: #767676;
 


### PR DESCRIPTION
A small fix to give double notes better readability and also fixes a regression that prevented flag and correct icons from showing.

Before:
![screen shot 2016-01-21 at 15 15 29](https://cloud.githubusercontent.com/assets/2061333/12484359/ecd49b54-c051-11e5-81d2-4af683f77030.png)

After:
![screen shot 2016-01-21 at 15 15 34](https://cloud.githubusercontent.com/assets/2061333/12484363/f22c022c-c051-11e5-9bc1-994309876bd3.png)

ref #143 