### PR TITLE
Pasting text inside notes leaves the note intact

### DIFF
--- a/src/actions/noting/wrap-in-note-around-paste.js
+++ b/src/actions/noting/wrap-in-note-around-paste.js
@@ -1,0 +1,31 @@
+var isScribeMarker = require('../../utils/noting/is-scribe-marker');
+var findPreviousNoteSegment = require('../../utils/noting/find-previous-note-segment');
+var findNextNoteSegment = require('../../utils/noting/find-next-note-segment');
+var removeScribeMarkers = require('./remove-scribe-markers');
+var createVirtualScribeMarker = require('../../utils/create-virtual-scribe-marker');
+var createNoteFromSelection = require('./create-note-from-selection');
+
+var notingVDom = require('../../noting-vdom');
+var mutate = notingVDom.mutate;
+var mutateScribe = notingVDom.mutateScribe;
+
+// Function to handle the case of pasting inside a note. Without these steps,
+// we would end up with the pasted content surrounded by two separate notes.
+// It finds the marker (current cursor position), the previous and next notes
+// (the ones we need to sew together) and wraps them into a new note.
+module.exports = function wrapInNoteAroundPaste() {
+  mutateScribe(scribe, focus => {
+    var marker = focus.find(isScribeMarker)
+    var prevNote = findPreviousNoteSegment(marker)
+    var nextNote = findNextNoteSegment(marker)
+
+    removeScribeMarkers(focus)
+
+    prevNote.prependChildren(createVirtualScribeMarker())
+    nextNote.addChild(createVirtualScribeMarker())
+
+    var selection = new scribe.api.Selection();
+
+    createNoteFromSelection(focus, undefined, true)
+  })
+}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -9,6 +9,8 @@ var config = {
   defaultTagName: 'gu-note',
   className: 'note',
   defaultClassName: 'note',
+  noteStartClassName: 'note--start',
+  noteEndClassName: 'note--end',
   dataName: 'data-note-edited-by',
   dataNameCamel: 'dataNoteEditedBy',
   dataDate: 'data-note-edited-date',

--- a/src/generate-note-controller.js
+++ b/src/generate-note-controller.js
@@ -151,18 +151,31 @@ module.exports = function(scribe){
       }
     }
 
+    // We assume user pasted inside a note if the number of notes changed.
     isPasteInsideNote() {
       var pos = scribe.undoManager.position
       var item = scribe.undoManager.item(pos)[0]
 
-      var tagName = config.get('defaultTagName')
+      var notesBeforePaste = countNotes(item.previousItem.content)
+      var notesAfterPaste = countNotes(item.content)
 
-      // split is the fastest way
-      // http://jsperf.com/find-number-of-occurrences-using-split-and-match
-      var notesBeforePaste = item.previousItem.content.split(tagName).length
-      var notesAfterPaste = item.content.split(tagName).length
+      return notesAfterPaste != notesBeforePaste
 
-      return notesAfterPaste > notesBeforePaste
+      // The number of notes in an HTML is the sum of number of note tags and start/end classes.
+      function countNotes(html) {
+        var hints = [
+          config.get('defaultTagName'),
+          config.get('noteStartClassName'),
+          config.get('noteEndClassName')
+        ]
+
+        // split is the fastest way
+        // http://jsperf.com/find-number-of-occurrences-using-split-and-match
+        return hints.reduce((p, c) => {
+          return p + html.split(c).length
+        }, 0)
+
+      }
     }
 
     // ------------------------------


### PR DESCRIPTION
Pasting into a note works as expected, fixes #152:

![paste](https://cloud.githubusercontent.com/assets/2061333/12555484/55d8fb8e-c379-11e5-9829-a21a8fde95f5.gif)

The current solution requires a history of the HTML of `scribe.el` in the plugin, that is lost when user uses *undo*, i.e. pasting will not work after an undo.