### PR TITLE
Fix: Unchecked expectations in wrapinnotearoundpaste

### DIFF
--- a/src/actions/noting/wrap-in-note-around-paste.js
+++ b/src/actions/noting/wrap-in-note-around-paste.js
@@ -1,3 +1,4 @@
+var config = require('../../config');
 var isScribeMarker = require('../../utils/noting/is-scribe-marker');
 var findPreviousNoteSegment = require('../../utils/noting/find-previous-note-segment');
 var findNextNoteSegment = require('../../utils/noting/find-next-note-segment');
@@ -15,23 +16,22 @@ var mutateScribe = notingVDom.mutateScribe;
 // (the ones we need to sew together) and wraps them into a new note.
 module.exports = function wrapInNoteAroundPaste(focus) {
   var marker = focus.find(isScribeMarker)
+  var tagNames = config.get('selectors').map(s => s.tagName)
 
-  var node = marker.find(focus => {
+  var prevNote = marker.find(focus => {
     if(!focus.vNode.tagName) {
       return false
     }
 
     let tagName = focus.vNode.tagName.toLowerCase()
-    return (tagName == "gu-note" || tagName == "gu-correct" || tagName == "gu-flag")
+    return tagNames.indexOf(tagName) > -1
   }, 'left')
 
-  if (!node) {
+  if (!prevNote) {
     return
   }
 
-  var tagName = node.vNode.tagName.toLowerCase()
-
-  var prevNote = findPreviousNoteSegment(marker, tagName)
+  var tagName = prevNote.vNode.tagName.toLowerCase()
   var nextNote = findNextNoteSegment(marker, tagName)
 
   if (!prevNote || !nextNote) {

--- a/src/actions/noting/wrap-in-note-around-paste.js
+++ b/src/actions/noting/wrap-in-note-around-paste.js
@@ -15,11 +15,21 @@ var mutateScribe = notingVDom.mutateScribe;
 // (the ones we need to sew together) and wraps them into a new note.
 module.exports = function wrapInNoteAroundPaste(focus) {
   var marker = focus.find(isScribeMarker)
-  try {
-    var tagName = marker.left().left().vNode.tagName.toLowerCase()
-  } catch(e) {
+
+  var node = marker.find(focus => {
+    if(!focus.vNode.tagName) {
+      return false
+    }
+
+    let tagName = focus.vNode.tagName.toLowerCase()
+    return (tagName == "gu-note" || tagName == "gu-correct" || tagName == "gu-flag")
+  }, 'left')
+
+  if (!node) {
     return
   }
+
+  var tagName = node.vNode.tagName.toLowerCase()
 
   var prevNote = findPreviousNoteSegment(marker, tagName)
   var nextNote = findNextNoteSegment(marker, tagName)

--- a/src/actions/noting/wrap-in-note-around-paste.js
+++ b/src/actions/noting/wrap-in-note-around-paste.js
@@ -34,7 +34,7 @@ module.exports = function wrapInNoteAroundPaste(focus) {
   var tagName = prevNote.vNode.tagName.toLowerCase()
   var nextNote = findNextNoteSegment(marker, tagName)
 
-  if (!prevNote || !nextNote) {
+  if (!nextNote) {
     return
   }
 

--- a/src/actions/noting/wrap-in-note-around-paste.js
+++ b/src/actions/noting/wrap-in-note-around-paste.js
@@ -15,13 +15,23 @@ var mutateScribe = notingVDom.mutateScribe;
 // (the ones we need to sew together) and wraps them into a new note.
 module.exports = function wrapInNoteAroundPaste(focus) {
   var marker = focus.find(isScribeMarker)
-  var prevNote = findPreviousNoteSegment(marker)
-  var nextNote = findNextNoteSegment(marker)
+  try {
+    var tagName = marker.left().left().vNode.tagName.toLowerCase()
+  } catch(e) {
+    return
+  }
+
+  var prevNote = findPreviousNoteSegment(marker, tagName)
+  var nextNote = findNextNoteSegment(marker, tagName)
+
+  if (!prevNote || !nextNote) {
+    return
+  }
 
   removeScribeMarkers(focus)
 
   prevNote.prependChildren(createVirtualScribeMarker())
   nextNote.addChild(createVirtualScribeMarker())
 
-  createNoteFromSelection(focus, undefined, true)
+  createNoteFromSelection(focus, tagName, true)
 }


### PR DESCRIPTION
Fixes #155 and allows pasting into all supported tags, not just `gu-note`