### PR TITLE
Un-noting a space inside a note properly creates two separate notes

### DIFF
--- a/src/actions/noting/remove-part-of-note.js
+++ b/src/actions/noting/remove-part-of-note.js
@@ -55,7 +55,17 @@ module.exports = function removePartofNote(focus, tagName = config.get('defaultT
   var entireNoteTextNodeFocuses = flatten(entireNote.map(flattenTree)).filter(isVText);
 
   var entireNoteTextNodes = entireNoteTextNodeFocuses.map(nodeFocus => nodeFocus.vNode);
-  var textNodesToUnote = focusesToUnnote.map(nodeFocus => nodeFocus.vNode);
+  var textNodesToUnote = focusesToUnnote.map(nodeFocus => {
+    // If the unnoted nodeFocus happens to be a space, we replace it with a
+    // placeholder, otherwise the note boundaries would not be detected.
+    if(nodeFocus.vNode.text === " ") {
+      var placeholder = new VText('\u200B \u200B')
+      nodeFocus.replace(placeholder)
+    }
+
+    return nodeFocus.vNode
+  });
+
   var toWrapAndReplace = difference(entireNoteTextNodes, textNodesToUnote);
 
   var focusesToNote = entireNoteTextNodeFocuses.filter(nodeFocus => {


### PR DESCRIPTION
Fixes #161 

![161](https://cloud.githubusercontent.com/assets/2061333/12850752/3d12d45a-cc1e-11e5-8af2-77aab1bb9287.gif)
